### PR TITLE
Replace list with old array for sortedallImageData to see what exactl…

### DIFF
--- a/exotic.py
+++ b/exotic.py
@@ -747,21 +747,19 @@ def check_targetpixelwcs(pixx, pixy, expra, expdec, ralist, declist):
 
 # Aligns imaging data from .fits file to easily track the host and comparison star's positions
 def image_alignment(sortedallImageData):
-    newlist, boollist = [], []
+    boollist = []
     notAligned = 0
 
     # Align images from .FITS files and catch exceptions if images can't be aligned. Keep two lists: newlist for
     # images aligned and boollist for discarded images to delete .FITS data from airmass and times.
-    for image_file in sortedallImageData:
+    for i, image_file in enumerate(sortedallImageData):
         try:
-            newData, footprint = aa.register(image_file, sortedallImageData[0])
-            newlist.append(newData)
+            sortedallImageData[i], footprint = aa.register(image_file, sortedallImageData[0])
             boollist.append(True)
         except:
             notAligned += 1
             boollist.append(False)
 
-    sortedallImageData = np.array(newlist)
     unalignedBoolList = np.array(boollist)
 
     if notAligned > 0:


### PR DESCRIPTION
…y is going on. Could one of the problems just be having to create a list of the same size and converting to a numpy array be what's causing the memory usage to be high? I made it replace old values within the sortedallImageData instead. If the files open fine when running through, they should be able to align just as properly if this isn't an astroalign problem. 