### PR TITLE
Issue 447: Headers w/ Plate Solutions now usable

### DIFF
--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -2294,6 +2294,7 @@ def main():
             while True:
                 fileNumber = 1
                 allImageData, timeList, fileNameList, timesListed, airMassList, fileNameStr, exptimes = [], [], [], [], [], [], []
+                time_dict = {}
 
                 # ----TIME SORT THE FILES-------------------------------------------------------------
                 for fileName in inputfiles:  # Loop through all the fits files in the directory and executes data reduction
@@ -2322,11 +2323,15 @@ def main():
                         del hdul
                         continue
 
-                    imageheader = hdul[0].header
+                    image_header = hdul[0].header
+
                     # TIME
                     timeVal = getJulianTime(hdul)  # gets the julian time registered in the fits header
                     timeList.append(timeVal)  # adds to time value list
                     fileNameList.append(fileName)
+
+                    # TIME DICT
+                    time_dict[fileName] = (timeVal, image_header)
 
                     # TIME
                     currTime = getJulianTime(hdul)
@@ -2341,11 +2346,11 @@ def main():
                     allImageData.append(hdul[0].data)
 
                     # EXPOSURE_TIME
-                    exp = imageheader.get('EXPTIME')  # checking for variation in .fits header format
+                    exp = image_header.get('EXPTIME')  # checking for variation in .fits header format
                     if exp:
-                        exptimes.append(imageheader['EXPTIME'])
+                        exptimes.append(image_header['EXPTIME'])
                     else:
-                        exptimes.append(imageheader['EXPOSURE'])
+                        exptimes.append(image_header['EXPOSURE'])
 
                     hdul.close()  # closes the file to avoid using up all of computer's resources
                     del hdul
@@ -2477,9 +2482,15 @@ def main():
                     log.info("Flattening images.")
                     sortedallImageData = sortedallImageData / generalFlat
 
-                # Reference File
+                for key, value in time_dict.items():
+                    if value[0] not in timesListed:
+                        time_dict.pop(key)
+
+                first_image = min(time_dict, key=lambda k: time_dict[k][0])
+
+                # Reference File w/ smallest time value
                 ref_file = Path(exotic_infoDict['saveplot']) / f'ref_file_{firstimagecounter}_'\
-                                                               f'{Path(fileNameStr[firstimagecounter]).name}'
+                                                               f'{Path(first_image).name}'
 
                 # Removes existing file of reference file. For future Python 3.8 update, .unlink(missing_ok=True)
                 # can be added to that will ignore exceptions such as the one below.
@@ -2488,7 +2499,7 @@ def main():
                 except FileNotFoundError:
                     pass
 
-                convertToFITS = fits.PrimaryHDU(data=sortedallImageData[0])
+                convertToFITS = fits.PrimaryHDU(data=sortedallImageData[0], header=time_dict[first_image][1])
                 convertToFITS.writeto(ref_file)
                 log.info(f"\nHere is the path to the reference imaging file used by EXOTIC: \n{ref_file}")
                 wcs_file = check_wcs(ref_file, exotic_infoDict['saveplot'], exotic_infoDict['plate_opt'])
@@ -2827,7 +2838,7 @@ def main():
             # Save an image of the FOV
             # (for now, take the first image; later will sum all of the images up)
             # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-            imscale = get_pixel_scale(hdulWCS, wcs_file, imageheader, exotic_infoDict['pixel_scale'])
+            imscale = get_pixel_scale(hdulWCS, wcs_file, image_header, exotic_infoDict['pixel_scale'])
             if hdulWCS:
                 hdulWCS.close()  # close stream
                 del hdulWCS
@@ -2890,7 +2901,7 @@ def main():
                      f"{exotic_infoDict['date']}_{str(stretch.__class__).split('.')[-1].split(apos)[0]}.pdf")
 
             # Take the BJD times from the image headers
-            if "BJD_TDB" in imageheader or "BJD" in imageheader:
+            if "BJD_TDB" in image_header or "BJD" in image_header:
                 goodTimes = nonBJDTimes
             # If not in there, then convert all the final times into BJD - using astropy alone
             else:

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -2480,9 +2480,7 @@ def main():
                     log.info("Flattening images.")
                     sortedallImageData = sortedallImageData / generalFlat
 
-                for key, value in time_dict.items():
-                    if value[0] not in timesListed:
-                        time_dict.pop(key)
+                time_dict = {k: v for k, v in time_dict.items() if v[0] in timesListed}
 
                 first_image = min(time_dict, key=lambda k: time_dict[k][0])
 


### PR DESCRIPTION
Closes #447

When creating a the reference file, the header was auto-generated with a standardized one, not the original. I went ahead and kept track of all the original headers of the files so that when creating the ref_file, it uses the original one after being sorted by time.