### PR TITLE
Issue 419: Adding uncertainties for inc and semi-major axis into previous metadata fields

### DIFF
--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -1368,8 +1368,9 @@ def get_pixel_scale(hdul, file, header, pixel_init):
 # Will remove later from code as these are older metadata formatting replaced by -XC. Kept for compatibility
 def previous_data_format(pdict, ld_0, ld_1, ld_2, ld_3, my_fit):
     return (f"#FILTER={exotic_infoDict['filter']}\n"
-            f"#PRIORS=Period={pdict['pPer']} +/- {pdict['pPerUnc']},a/R*={pdict['aRs']},inc={pdict['inc']}"
-            f",ecc={pdict['ecc']},u0={ld_0[0]} +/- {ld_0[1]},u1={ld_1[0]} +/- {ld_1[1]},u2={ld_2[0]} +/- {ld_2[1]}"
+            f"#PRIORS=Period={pdict['pPer']} +/- {pdict['pPerUnc']},a/R*={pdict['aRs']} +/- {pdict['aRsUnc']}"
+            f",inc={pdict['inc']} +/- {pdict['incUnc']},ecc={pdict['ecc']}"
+            f",u0={ld_0[0]} +/- {ld_0[1]},u1={ld_1[0]} +/- {ld_1[1]},u2={ld_2[0]} +/- {ld_2[1]}"
             f",u3={ld_3[0]} +/- {ld_3[1]}\n"
             f"#RESULTS=Tc={round(my_fit.parameters['tmid'], 8)} +/- {round(my_fit.errors['tmid'], 8)}"		
             f",Rp/R*={round(my_fit.parameters['rprs'], 6)} +/- {round(my_fit.errors['rprs'], 6)}"		


### PR DESCRIPTION
Sample metadata: 

#TYPE=EXOPLANET
#OBSCODE=RTZ
#SECONDARY_OBSCODE=N/A
#SOFTWARE=EXOTIC v0.27.0
#DELIM=,
#DATE_TYPE=BJD_TDB
#OBSTYPE=CCD
#STAR_NAME=HAT-P-32
#EXOPLANET_NAME=HAT-P-32 b
#BINNING=1x1
#EXPOSURE_TIME=60.0
#FILTER-XC={"name": "V", "fwhm": ["502.8", "586.8"]}
#COMP_STAR-XC={"ra": null, "dec": null, "x": null, "y": null}
#NOTES=Weather, seeing was nice.
#DETREND_PARAMETERS=AIRMASS, AIRMASS CORRECTION FUNCTION
#MEASUREMENT_TYPE=Rnflux
#PRIORS-XC={"Period": {"value": "2.1500082", "uncertainty": "1.3e-07"}, "a/R*": {"value": "5.344", "uncertainty": "0.039496835316262996"}, "inc": {"value": "88.98", "uncertainty": "0.7602631123499285"}, "ecc": {"value": "0.159", "uncertainty": null}, "u0": {"value": "1.8836722036814506", "uncertainty": "0.04578423324405865"}, "u1": {"value": "-3.3253403593186226", "uncertainty": "0.1849474576116671"}, "u2": {"value": "3.9215380170922645", "uncertainty": "0.24089508089443187"}, "u3": {"value": "-1.4798698614550925", "uncertainty": "0.1017238536319961"}}
#RESULTS-XC={"Tc": {"value": "2458107.71365725", "uncertainty": "0.00092849"}, "Rp/R*": {"value": "0.153126", "uncertainty": "0.003025"}, "Am1": {"value": "7431.28972", "uncertainty": "22.93357"}, "Am2": {"value": "-0.11822", "uncertainty": "0.00235"}}
#FILTER=V
#PRIORS=Period=2.1500082 +/- 1.3e-07,a/R*=5.344 +/- 0.039496835316262996,inc=88.98 +/- 0.7602631123499285,ecc=0.159,u0=1.8836722036814506 +/- 0.04578423324405865,u1=-3.3253403593186226 +/- 0.1849474576116671,u2=3.9215380170922645 +/- 0.24089508089443187,u3=-1.4798698614550925 +/- 0.1017238536319961
#RESULTS=Tc=2458107.71365725 +/- 0.00092849,Rp/R*=0.153126 +/- 0.003025,Am1=7431.28972 +/- 22.93357,Am2=-0.11822 +/- 0.00235
#DATE,FLUX,MERR,DETREND_1,DETREND_2