### PR TITLE
Modification to WCS inputs

### DIFF
--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -1171,34 +1171,19 @@ def check_wcs(fits_file, save_directory, plate_opt):
         hdulist.close()
         del hdulist
 
+    if plate_opt not in ('y', 'n'):
+        plate_opt = user_input("\nWould you like to upload the your image for a plate solution?"
+                               "\nDISCLAIMER: One of your imaging files will be publicly viewable "
+                               "on nova.astrometry.net. (y/n): ", type_=str, val1='y', val2='n')
+
     if plate_opt == 'y':
         return get_wcs(fits_file, save_directory)
     elif plate_opt == 'n':
         if wcs_exists:
-            trust_wcs = user_input("The imaging data from your file has WCS information. Do you trust this? (y/n): ",
-                                   type_=str, val1='y', val2='n')
-
-            if trust_wcs == 'y':
-                return fits_file
-            else:
-                return False
-    else:
-        if wcs_exists:
-            trust_wcs = user_input("The imaging data from your file has WCS information. Do you trust this? (y/n): ",
-                                   type_=str, val1='y', val2='n')
-        else:
-            trust_wcs = 'n'
-
-        if trust_wcs == 'n':
-            opt = user_input("\nWould you like to upload the your image for a plate solution?"
-                             "\nDISCLAIMER: One of your imaging files will be publicly viewable on nova.astrometry.net."
-                             " (y/n): ", type_=str, val1='y', val2='n')
-            if opt == 'y':
-                return get_wcs(fits_file, save_directory)
-            else:
-                return False
-        else:
+            print("WARNING: FITS file has WCS in the header. EXOTIC will proceed to utilize WCS in the header.")
             return fits_file
+        else:
+            return False
 
 
 def get_wcs(file, directory=""):

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -1180,7 +1180,9 @@ def check_wcs(fits_file, save_directory, plate_opt):
         return get_wcs(fits_file, save_directory)
     elif plate_opt == 'n':
         if wcs_exists:
-            print("WARNING: FITS file has WCS in the header. EXOTIC will proceed to utilize WCS in the header.")
+            log.info("Your FITS files have WCS information in their headers. EXOTIC will proceed to use these. "
+                     "NOTE: If you do not trust your WCS coordinates, "
+                     "please restart EXOTIC after enabling plate solutions via astrometry.net.")
             return fits_file
         else:
             return False


### PR DESCRIPTION
Updated how we ask for user input regarding WCS files. If the user opts for 'y', EXOTIC will get WCS from astrometry.net. If the user opts for 'n', EXOTIC will check the header for WCS and inform the user or return `False` for no WCS used.