### PR TITLE
stop fitting if the data can't constrain the model

### DIFF
--- a/exotic/api/elca.py
+++ b/exotic/api/elca.py
@@ -323,7 +323,7 @@ class lc_fitter(object):
             maxiter_init=5000, dlogz_init=1, dlogz=0.05,
             maxiter_batch=100, maxbatch=10, nlive_batch=100
         )
-        dsampler.run_nested()
+        dsampler.run_nested(maxcall=1e6)
         self.results = dsampler.results
 
         # alloc data for best fit + error


### PR DESCRIPTION
If the data can't constrain the model after 100,000 function calls then stop the fitting process.