### PR TITLE
Update ecla.py with jit on solveme

### DIFF
--- a/exotic/api/elca.py
+++ b/exotic/api/elca.py
@@ -43,6 +43,7 @@
 # ########################################################################### #
 
 import copy
+from numba import jit
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -186,13 +187,13 @@ def time2z(time, ipct, tknot, sma, orbperiod, ecc, tperi=None, epsilon=1e-5):
     z[sft < 0] *= -1e0
     return z, sft
 
-
+@jit(nopython=True)
 def solveme(M, e, eps):
     '''
     G. ROUDIER: Newton Raphson solver for true anomaly
     M is a numpy array
     '''
-    E = np.copy(M)
+    E = M.copy() # numba only allows copy() with no arguments
     for i in np.arange(M.shape[0]):
         while abs(E[i] - e*np.sin(E[i]) - M[i]) > eps:
             num = E[i] - e*np.sin(E[i]) - M[i]


### PR DESCRIPTION
Using EXOTIC 0.43.0 with sample-data the run time for solveme function is reduced from around 400 seconds to around 3 seconds by using Numba JIT. Overall EXOTIC run time is reduced from around 1,400 seconds (23 min) to around 1,000 seconds (17 min). This effect should be more pronounced on longer data-reduction runs where "pre data-reduction" stages in overall EXOTIC process are less significant. 
This has been tested successfully with EXOTIC 0.44.2 and the "jitted" results found to be more or less identical to the "un-jitted" results.