### PR TITLE
Issue 657: Checking for Valid JSON

### DIFF
--- a/exotic/inputs.py
+++ b/exotic/inputs.py
@@ -1,7 +1,7 @@
 import logging
 import sys
+import json
 from pathlib import Path
-from json import load
 
 try:
     from util import user_input, dms_to_dd, open_elevation, typecast_check, init_params
@@ -121,7 +121,7 @@ class Inputs:
 
     def comp_params(self, init_file, planet_dict):
         with init_file.open('r') as json_file:
-            data = load(json_file)
+            data = json.load(json_file)
 
         user_info = {
             'images': 'Directory with FITS files', 'save': 'Directory to Save Plots',

--- a/exotic/inputs.py
+++ b/exotic/inputs.py
@@ -1,7 +1,7 @@
 import logging
-import json
 import sys
 from pathlib import Path
+from json import load
 
 try:
     from util import user_input, dms_to_dd, open_elevation, typecast_check, init_params
@@ -115,10 +115,13 @@ class Inputs:
                 [log_info(f"\t{file}") for file in cwd.glob('*.json') if file.is_file()]
 
                 init_file = None
+            except ValueError as e:
+                log_info(f"\nError: Invalid JSON. Please reformat JSON based on given suggestion:\n\t - {e}")
+                init_file = None
 
     def comp_params(self, init_file, planet_dict):
         with init_file.open('r') as json_file:
-            data = json.load(json_file)
+            data = load(json_file)
 
         user_info = {
             'images': 'Directory with FITS files', 'save': 'Directory to Save Plots',


### PR DESCRIPTION
EXOTIC will no longer error out when an invalid format of a JSON is given for an initialization file. For example, when a comma is missing, the following will output and loop again to ask for an initialization file: 

`Error: Invalid JSON. Please reformat JSON based on given suggestion:`
	` - Expecting ',' delimiter: line 32 column 13 (char 2551)`

The errors printed above are coming directly from the JSON module and gives a bit more readability. ~~Closes #657~~