### PR TITLE
Increased Speed For Fitting a Light Curve

### DIFF
--- a/exotic/api/elca.py
+++ b/exotic/api/elca.py
@@ -43,7 +43,7 @@
 # ########################################################################### #
 
 import copy
-from numba import jit
+from numba import njit
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -146,10 +146,12 @@ def vecoccs(z, xrs, rprs):
     return out
 
 
+@njit
 def time2z(time, ipct, tknot, sma, orbperiod, ecc, tperi=None, epsilon=1e-5):
     '''
     G. ROUDIER: Time samples in [Days] to separation in [R*]
     '''
+    tperii = 0
     if tperi is not None:
         ft0 = (tperi - tknot) % orbperiod
         ft0 /= orbperiod
@@ -161,14 +163,15 @@ def time2z(time, ipct, tknot, sma, orbperiod, ecc, tperi=None, epsilon=1e-5):
         w = np.angle(np.complex(realf, imagf))
         if abs(ft0) < epsilon:
             w = np.pi/2e0
-            tperi = tknot
+            tperii = tknot
             pass
         pass
     else:
         w = np.pi/2e0
-        tperi = tknot
+        tperii = tknot
         pass
-    ft = (time - tperi) % orbperiod
+
+    ft = (time - tperii) % orbperiod
     ft /= orbperiod
     sft = np.copy(ft)
     sft[(sft > 0.5)] += -1e0
@@ -187,7 +190,8 @@ def time2z(time, ipct, tknot, sma, orbperiod, ecc, tperi=None, epsilon=1e-5):
     z[sft < 0] *= -1e0
     return z, sft
 
-@jit(nopython=True)
+
+@njit
 def solveme(M, e, eps):
     '''
     G. ROUDIER: Newton Raphson solver for true anomaly
@@ -203,14 +207,17 @@ def solveme(M, e, eps):
         pass
     return E
 
+
 def transit(time, values):
     sep,phase = time2z(time, values['inc'], values['tmid'], values['ars'], values['per'], values['ecc'])
     model = tldlc(abs(sep), values['rprs'], values['u0'], values['u1'], values['u2'], values['u3'])
     return model
 
+
 def getPhase(curTime, pPeriod, tMid):
     phase = (curTime - tMid) / pPeriod
     return phase - int(np.nanmin(phase))
+
 
 # average data into bins of dt from start to finish
 def time_bin(time, flux, dt):
@@ -224,6 +231,7 @@ def time_bin(time, flux, dt):
             btime[i] = np.nanmean(time[mask])
     zmask = (bflux==0) | (btime==0) | np.isnan(bflux) | np.isnan(btime)
     return btime[~zmask], bflux[~zmask]
+
 
 # Function that bins an array
 def binner(arr, n, err=''):
@@ -457,6 +465,7 @@ class lc_fitter(object):
         fig,axs = dynesty.plotting.cornerplot(self.results, labels=list(self.bounds.keys()), quantiles_2d=[0.4,0.85], smooth=0.015, show_titles=True,use_math_text=True, title_fmt='.2e',hist2d_kwargs={'alpha':1,'zorder':2,'fill_contours':False})
         dynesty.plotting.cornerpoints(self.results, labels=list(self.bounds.keys()), fig=[fig,axs[1:,:-1]],plot_kwargs={'alpha':0.1,'zorder':1,} )
         return fig, axs
+
 
 if __name__ == "__main__":
 

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -2641,73 +2641,73 @@ def main():
         ##########
         # PSF data
         ##########
-
-        fig, ax = plt.subplots(3,2, figsize=(12,10))
-        fig.suptitle(f"Observing Statistics - Target - {exotic_infoDict['date']}")
-        ax[0,0].plot(myfit.time, psf_data['target'][si,0][gi], 'k.')
-        ax[0,0].set_ylabel("X-Centroid [px]")
-        ax[0,1].plot(myfit.time, psf_data['target'][si,1][gi], 'k.')
-        ax[0,1].set_ylabel("Y-Centroid [px]")
-        ax[1,0].plot(myfit.time, 2.355*0.5*(psf_data['target'][si,3][gi] + psf_data['target'][si,4][gi]), 'k.')
-        ax[1,0].set_ylabel("Seeing [px]")
-        ax[1,1].plot(myfit.time, myfit.airmass, 'k.')
-        ax[1,1].set_ylabel("Airmass")
-        ax[2,0].plot(myfit.time, psf_data['target'][si,2][gi], 'k.')
-        ax[2,1].plot(myfit.time, psf_data['target'][si,6][gi], 'k.')
-        ax[2,0].set_ylabel("Amplitude [ADU]")
-        ax[2,1].set_ylabel("Background [ADU]")
-        ax[0,0].set_xlabel("Time [BJD]")
-        ax[0,1].set_xlabel("Time [BJD]")
-        ax[1,0].set_xlabel("Time [BJD]")
-        ax[1,1].set_xlabel("Time [BJD]")
-        ax[2,0].set_xlabel("Time [BJD]")
-        ax[2,1].set_xlabel("Time [BJD]")
-        plt.tight_layout()
-
-        try:
-            fig.savefig(Path(exotic_infoDict['save']) /
-                        f"Observing_Statistics_target_{exotic_infoDict['date']}.png", bbox_inches="tight")
-        except:
-            pass
-        fig.savefig(Path(exotic_infoDict['save']) /
-                    f"Observing_Statistics_target_{exotic_infoDict['date']}.pdf", bbox_inches="tight")
-        plt.close()
-
-        # PSF DATA for COMP STARS
-        for j,coord in enumerate(compStarList):
-            ctitle = "Comp Star {}".format(j+1)
-            ckey = "comp{}".format(j+1)
-
+        if fitsortext == 1:
             fig, ax = plt.subplots(3,2, figsize=(12,10))
-            fig.suptitle(f"Observing Statistics - {ctitle} - {exotic_infoDict['date']}")
-            ax[0,0].plot(myfit.time, psf_data[ckey][si,0][gi], 'k.')
+            fig.suptitle(f"Observing Statistics - Target - {exotic_infoDict['date']}")
+            ax[0,0].plot(myfit.time, psf_data['target'][si,0][gi], 'k.')
             ax[0,0].set_ylabel("X-Centroid [px]")
-            ax[0,1].plot(myfit.time, psf_data[ckey][si,1][gi], 'k.')
+            ax[0,1].plot(myfit.time, psf_data['target'][si,1][gi], 'k.')
             ax[0,1].set_ylabel("Y-Centroid [px]")
-            ax[1,0].plot(myfit.time, 2.355*0.5*(psf_data[ckey][si,3][gi] + psf_data[ckey][si,4][gi]), 'k.')
+            ax[1,0].plot(myfit.time, 2.355*0.5*(psf_data['target'][si,3][gi] + psf_data['target'][si,4][gi]), 'k.')
             ax[1,0].set_ylabel("Seeing [px]")
             ax[1,1].plot(myfit.time, myfit.airmass, 'k.')
             ax[1,1].set_ylabel("Airmass")
-            ax[2,0].plot(myfit.time, psf_data[ckey][si,2][gi], 'k.')
-            ax[2,1].plot(myfit.time, psf_data[ckey][si,6][gi], 'k.')
+            ax[2,0].plot(myfit.time, psf_data['target'][si,2][gi], 'k.')
+            ax[2,1].plot(myfit.time, psf_data['target'][si,6][gi], 'k.')
             ax[2,0].set_ylabel("Amplitude [ADU]")
             ax[2,1].set_ylabel("Background [ADU]")
-            ax[0,0].set_xlabel("Time [BJD_TBD]")
-            ax[0,1].set_xlabel("Time [BJD_TBD]")
-            ax[1,0].set_xlabel("Time [BJD_TBD]")
-            ax[1,1].set_xlabel("Time [BJD_TBD]")
-            ax[2,0].set_xlabel("Time [BJD_TBD]")
-            ax[2,1].set_xlabel("Time [BJD_TBD]")
+            ax[0,0].set_xlabel("Time [BJD]")
+            ax[0,1].set_xlabel("Time [BJD]")
+            ax[1,0].set_xlabel("Time [BJD]")
+            ax[1,1].set_xlabel("Time [BJD]")
+            ax[2,0].set_xlabel("Time [BJD]")
+            ax[2,1].set_xlabel("Time [BJD]")
             plt.tight_layout()
 
             try:
                 fig.savefig(Path(exotic_infoDict['save']) /
-                            f"Observing_Statistics_{ckey}_{exotic_infoDict['date']}.pdf", bbox_inches="tight")
+                            f"Observing_Statistics_target_{exotic_infoDict['date']}.png", bbox_inches="tight")
             except:
                 pass
             fig.savefig(Path(exotic_infoDict['save']) /
-                        f"Observing_Statistics_{ckey}_{exotic_infoDict['date']}.png", bbox_inches="tight")
+                        f"Observing_Statistics_target_{exotic_infoDict['date']}.pdf", bbox_inches="tight")
             plt.close()
+
+            # PSF DATA for COMP STARS
+            for j,coord in enumerate(compStarList):
+                ctitle = "Comp Star {}".format(j+1)
+                ckey = "comp{}".format(j+1)
+
+                fig, ax = plt.subplots(3,2, figsize=(12,10))
+                fig.suptitle(f"Observing Statistics - {ctitle} - {exotic_infoDict['date']}")
+                ax[0,0].plot(myfit.time, psf_data[ckey][si,0][gi], 'k.')
+                ax[0,0].set_ylabel("X-Centroid [px]")
+                ax[0,1].plot(myfit.time, psf_data[ckey][si,1][gi], 'k.')
+                ax[0,1].set_ylabel("Y-Centroid [px]")
+                ax[1,0].plot(myfit.time, 2.355*0.5*(psf_data[ckey][si,3][gi] + psf_data[ckey][si,4][gi]), 'k.')
+                ax[1,0].set_ylabel("Seeing [px]")
+                ax[1,1].plot(myfit.time, myfit.airmass, 'k.')
+                ax[1,1].set_ylabel("Airmass")
+                ax[2,0].plot(myfit.time, psf_data[ckey][si,2][gi], 'k.')
+                ax[2,1].plot(myfit.time, psf_data[ckey][si,6][gi], 'k.')
+                ax[2,0].set_ylabel("Amplitude [ADU]")
+                ax[2,1].set_ylabel("Background [ADU]")
+                ax[0,0].set_xlabel("Time [BJD_TBD]")
+                ax[0,1].set_xlabel("Time [BJD_TBD]")
+                ax[1,0].set_xlabel("Time [BJD_TBD]")
+                ax[1,1].set_xlabel("Time [BJD_TBD]")
+                ax[2,0].set_xlabel("Time [BJD_TBD]")
+                ax[2,1].set_xlabel("Time [BJD_TBD]")
+                plt.tight_layout()
+
+                try:
+                    fig.savefig(Path(exotic_infoDict['save']) /
+                                f"Observing_Statistics_{ckey}_{exotic_infoDict['date']}.pdf", bbox_inches="tight")
+                except:
+                    pass
+                fig.savefig(Path(exotic_infoDict['save']) /
+                            f"Observing_Statistics_{ckey}_{exotic_infoDict['date']}.png", bbox_inches="tight")
+                plt.close()
 
 
         #######################################################################


### PR DESCRIPTION
Increased speed for fitting a light curve. Before decorator `njit` on `time2z()`, total time to complete HAT-P-32 b's fitting for a lightcurve was `4:53`. After njit, `3:59`. ~18.5% decease in time on the model alone.

Thanks to @Zorba256 for giving me advice on how to complete this. This can definitely be utilized all over EXOTIC the more we start to organize our functions, especially in areas such as our photometric extractions.

There seems to be a bug in `Numba` that made this difficult to work before on `None` types. My simple change after researching their GitHub Repo made it possible to utilize it on `time2z()`.