### PR TITLE
Update EXOTIC Installation Instructions for Ubuntu.md

### DIFF
--- a/Documentation/English/EXOTIC Installation Instructions for Ubuntu.md
+++ b/Documentation/English/EXOTIC Installation Instructions for Ubuntu.md
@@ -21,22 +21,26 @@ Once you are happy running running EXOTIC with the Colab and you want to run you
 
 Early versions of EXOTIC had to be run wholly on the "command line" whereby responses to the prompts from the program had to be typed in line by line as the program ran each step. EXOTIC itself still runs in a command line window but you can now enter your choices for the various program options via a series of pop up screens before commencing the data-reduction run.
 
+*Note: you may be running your Ubuntu on Windows 10 using the WSL2 feature, whereby you can install a Linux OS on top of Windows itself. Unfortunately this arrangement does not currently support the use of a GUI (graphical user interface) such as that now required by EXOTIC. Microsoft have plans to enable a GUI for Ubuntu on WSL2, probably later in 2021 but until then EXOTIC will not run on this environment.  If you try to do so you will see errors upon starting EXOTIC stating "tkinter.TclError: no display name and no $DISPLAY environment variable".*
+
+*Users with Windows computers now do not need to install Ubuntu or any other flavour of Linux in order to run EXOTIC - since the program will now run on Windows itself. For more details of how to install EXOTIC on Windows see the "EXOTIC installation instructions for Windows" in the documentation pages  [EXOTIC Project on GitHub](https://github.com/rzellem/EXOTIC/tree/main/Documentation).*
+
 ## Installing EXOTIC for Ubuntu
 
 1. #### Installing/updating Python and supporting files
 
    Execute the commands shown in the boxes below by typing them on the Ubuntu command line after the prompt symbol "$". After entering each command you will need to press the Enter (or Return) key and wait for it to complete, which is when the prompt reappears.
 
-   Start by updating your Ubuntu system to the latest version and then proceed to install the additional software necessary to run the EXOTIC program.
+   EXOTIC is known to run successfully on both Ubuntu 18.04 LTS and Ubuntu 20.04 LTS but it may also be supported on other releases of Ubuntu. Start by updating your Ubuntu system with the latest version of all installed packages and then proceed to install the additional software necessary to run the EXOTIC program.
 
-   1.1 Update the list of software packages available in the repository of Ubuntu software. The "sudo" command enables you to run packages normally requiring root privileges, so you will need to enter the root password when prompted. This command will show you all the packages that can be upgraded and any available essential new packages and then download them for you.
+   1.1 Update the list of software packages available in the repository of Ubuntu software. The "sudo" command enables you to run packages normally requiring root privileges, so you will need to enter the root password when prompted. This command will show you all the packages that can be upgraded, as well as any available essential new packages and then download them for you.
 
 
    ```python
      $ sudo apt update
    ```
 
-   1.2 Update each package  to its latest version. You will see a list of the packages being upgraded or installed, as well as a progress bar showing the progress of the overall upgrade to your Ubuntu system.
+   1.2 Update each package to its latest version. You will see a list of the packages being upgraded or installed, as well as a progress bar showing the progress of the overall upgrade to your Ubuntu system.
 
 
    ```python
@@ -65,9 +69,11 @@ Early versions of EXOTIC had to be run wholly on the "command line" whereby resp
 
 2. #### Downloading EXOTIC and supporting files
 
-   2.1 Go to the home page of the [EXOTIC project](https://pypi.org/project/exotic/) at the Python Package Index (PyPI). This site hosts many major Python projects for a variety of computer platforms, including both Linux and Windows machines. Here you will find links to all aspects of the EXOTIC project including the documentation and the software itself. Follow the "Homepage" link in the left hand margin that will take you to the [EXOTIC home page on GitHub](https://github.com/rzellem/EXOTIC), where the software for the project is developed. 
+   2.1 Go to the home page of the [EXOTIC project](https://pypi.org/project/exotic/) at the Python Package Index (PyPI). This site hosts many major Python projects for a variety of computer platforms, including both Linux and Windows machines. Here you will find links to many components of the EXOTIC project, including copies of the documentation and the EXOTIC software itself. 
 
-   2.2 Click the "Releases" link in the right hand margin of the EXOTIC home page on GitHub. On the next page you will find a series of releases of EXOTIC, each with a header outlining the key change for that version. The most recent version of EXOTIC (labelled "Latest release" in the left hand margin) is shown at the top. Go to the "Assets" section to get a copy of the latest release and right click the "Source code (tar.gz)" link to download the compressed archive containing the full set of files. This archive file will be named "EXOTIC" followed by the release number e.g. "EXOTIC-0.45.3.zip". Save the file to the usual folder on your computer where your browser stores downloaded  files. 
+   2.2 Click the "Download files" link in the left hand margin of the EXOTIC home page on PyPi. On the next page you will find files in various formats for the latest release of EXOTIC, each with a different file extension. The archive file you need will have a name beginning "exotic-" followed by the release number and finally the extension ".tar.gz" (for example "exotic-1.0.0.tar.gz)". Right click the file name link to download the compressed archive containing the full set of files. 
+
+   2.3 Save the file to the usual folder on your computer where your browser stores downloaded files. 
 
 3. #### Installing EXOTIC
 
@@ -87,7 +93,9 @@ Early versions of EXOTIC had to be run wholly on the "command line" whereby resp
    3.3 Start by copying the EXOTIC compressed files from where you downloaded them into the directory for running EXOTIC that you created above. This command will copy the software package, where "n.nn.n" is the number of your release of EXOTIC in the downloaded file name and **<exotic>** is the name of the directory that you created above.
 
       ```python
-   $ cp EXOTIC-n.nn.n.zip ~/<exotic>
+   $ cp EXOTIC-n.nn.n.tar.gz ~/<exotic>
+
+      ```
       ```
 
    3.4 Now you need to step into the directory where the EXOTIC files have just been copied and get ready to extract and decompress the software. Replace **<exotic>** with the directory that you created above.
@@ -99,19 +107,23 @@ Early versions of EXOTIC had to be run wholly on the "command line" whereby resp
    3.5 Then the EXOTIC software needs to be extracted from the archive file into the directory where you are now located.
 
    ```python
-   $ unzip EXOTIC-n.nn.n.zip
+   $ tar -xf exotic-n.nn.n.tar.gz
    ```
 
    3.6 Now you need to step into the directory where the EXOTIC files have just been placed before you can run the software. The actual directory name will reflect both the directory in which you originally chose to place your files and the version of EXOTIC that you have downloaded.
 
       ```python
-   $ cd ~/<exotic>/EXOTIC-n.nn.n
+   $ cd ~/<exotic>/exotic-n.nn.n
+
+      ```
       ```
 
    3.7 Run this script to verify that you have suitable versions of Python and pip and then install all the necessary packages to run EXOTIC. Enter the password you created above if prompted.
 
       ```python
    $ ./run_exotic_linux.sh
+
+      ```
       ```
 
    3.8 Wait a while. This process will take up to around 15 minutes to download and install the complete EXOTIC system.
@@ -124,9 +136,19 @@ Early versions of EXOTIC had to be run wholly on the "command line" whereby resp
 
    You can move each window around separately to see what is happening in each of them.
 
+   *3.10 Note: Depending upon the release of Ubuntu and the version of Python you are using, you may see an error referring to the lack of a package called "tkinter" on your system when you try to run EXOTIC. (For example "ImportError: No module named tkinter".) Do not be alarmed, although tkinter is the key component required to display the EXOTIC GUI, this issue can be easily fixed by installing the missing software.*
+
+   3.11 In this case run the following command to install the necessary package for tkinter. Enter the password you created above if prompted.
+
+   ```python
+   $ sudo apt install python3-tk
+   ```
+Then try running EXOTIC again, as detailed in the next section.
+
+
 ## Running EXOTIC next time
 
-To run the EXOTIC program in the future, simply click locate and run the "run_exotic_linux.sh" file again. This will firstly check whether any EXOTIC files need updating and update them automatically if there has been another release of the software. In this case you will see the same installation process as outlined above, though it will run very much faster, as most files will not have changed between releases. 
+To run the EXOTIC program in the future, simply locate and run the "run_exotic_linux.sh" file again. This will firstly check whether any EXOTIC files need updating and update them automatically if there has been another release of the software. In this case you will see the same installation process as outlined above, though it will run very much faster, as most files will not have changed between releases. 
 
 After the installation of any new or updated EXOTIC components has completed (or is skipped through if nothing has changed) the program will run as before.
 

--- a/Documentation/English/EXOTIC Installation Instructions for Windows 10.md
+++ b/Documentation/English/EXOTIC Installation Instructions for Windows 10.md
@@ -42,11 +42,11 @@ Right click to download and save the EXE file to your computer and double click 
 
 2. #### Downloading EXOTIC and supporting files
 
-Go to the home page of the [EXOTIC project](https://pypi.org/project/exotic/) at the Python Package Index (PyPI). This site hosts many major Python projects for a variety of computer platforms, including both Linux and Windows machines. Here you will find links to all aspects of the EXOTIC project including the documentation and the software itself. Follow the "Homepage" link in the left hand margin that will take you to the [EXOTIC home page on GitHub](https://github.com/rzellem/EXOTIC), where the software for the project is developed. 
+2.1 Go to the home page of the [EXOTIC project](https://pypi.org/project/exotic/) at the Python Package Index (PyPI). This site hosts many major Python projects for a variety of computer platforms, including both Linux and Windows machines. Here you will find links to many components of the EXOTIC project, including copies of the documentation and the EXOTIC software itself. 
 
-Click the "Releases" link in the right hand margin of the EXOTIC home page on GitHub. On the next page you will find a series of releases of EXOTIC, each with a header outlining the key change for that version. The most recent version of EXOTIC (labelled "Latest release" in the left hand margin) is shown at the top. Go to the "Assets" section to get a copy of the latest release and right click the "Source code (zip)" link to download the compressed file. This file will be named "EXOTIC" followed by the release number e.g. "EXOTIC-0.45.3.zip". Save the file to the usual folder on your computer where your browser stores downloaded  files. 
+2.2 Click the "Download files" link in the left hand margin of the EXOTIC home page on PyPi. On the next page you will find files in various formats for the latest release of EXOTIC, each with a different file extension. The archive file you need will have a name beginning "exotic-" followed by the release number and finally the extension ".zip" (for example "exotic-1.3.3.zip)". Right click the file name link to download the compressed archive containing the full set of files. 
 
-Go to that downloads folder and right click the zip file that you have just saved and choose the "Extract All..." option. In the window that pops up, choose where to install the EXOTIC files, make sure the "Show extracted files when complete" box is ticked and click "Extract". After extraction, a new window will open up showing the folder where the files are located, named after the version of the EXOTIC program (e.g. EXOTIC-0.45.3). 
+2.3 Go to the folder where you downloaded the file and right click the zip file that you have just saved and choose the "Extract All..." option. In the window that pops up, choose where to install the EXOTIC files, make sure the "Show extracted files when complete" box is ticked and click "Extract". After extraction, a new window will open up showing the folder where the files are located, named after the version of the EXOTIC program (e.g. EXOTIC1.3.3). 
 
 3. #### Installing EXOTIC
 
@@ -90,4 +90,6 @@ After installing EXOTIC itself, you may wish to install the SAOImageDS9 (Astrono
 ## Further Help and Support
 
 If you have any questions or comments, please feel free to reach out to us on Slack or email at [exoplanetwatch@jpl.nasa.gov](exoplanetwatch@jpl.nasa.gov)
+
+
 

--- a/Documentation/English/EXOTIC Installation Instructions for Windows 10.md
+++ b/Documentation/English/EXOTIC Installation Instructions for Windows 10.md
@@ -42,11 +42,11 @@ Right click to download and save the EXE file to your computer and double click 
 
 2. #### Downloading EXOTIC and supporting files
 
-2.1 Go to the home page of the [EXOTIC project](https://pypi.org/project/exotic/) at the Python Package Index (PyPI). This site hosts many major Python projects for a variety of computer platforms, including both Linux and Windows machines. Here you will find links to many components of the EXOTIC project, including copies of the documentation and the EXOTIC software itself. 
+Go to the home page of the [EXOTIC project](https://pypi.org/project/exotic/) at the Python Package Index (PyPI). This site hosts many major Python projects for a variety of computer platforms, including both Linux and Windows machines. Here you will find links to all aspects of the EXOTIC project including the documentation and the software itself. Follow the "Homepage" link in the left hand margin that will take you to the [EXOTIC home page on GitHub](https://github.com/rzellem/EXOTIC), where the software for the project is developed. 
 
-2.2 Click the "Download files" link in the left hand margin of the EXOTIC home page on PyPi. On the next page you will find files in various formats for the latest release of EXOTIC, each with a different file extension. The archive file you need will have a name beginning "exotic-" followed by the release number and finally the extension ".zip" (for example "exotic-1.3.3.zip)". Right click the file name link to download the compressed archive containing the full set of files. 
+Click the "Releases" link in the right hand margin of the EXOTIC home page on GitHub. On the next page you will find a series of releases of EXOTIC, each with a header outlining the key change for that version. The most recent version of EXOTIC (labelled "Latest release" in the left hand margin) is shown at the top. Go to the "Assets" section to get a copy of the latest release and right click the "Source code (zip)" link to download the compressed file. This file will be named "EXOTIC" followed by the release number e.g. "EXOTIC-0.45.3.zip". Save the file to the usual folder on your computer where your browser stores downloaded  files. 
 
-2.3 Go to the folder where you downloaded the file and right click the zip file that you have just saved and choose the "Extract All..." option. In the window that pops up, choose where to install the EXOTIC files, make sure the "Show extracted files when complete" box is ticked and click "Extract". After extraction, a new window will open up showing the folder where the files are located, named after the version of the EXOTIC program (e.g. EXOTIC1.3.3). 
+Go to that downloads folder and right click the zip file that you have just saved and choose the "Extract All..." option. In the window that pops up, choose where to install the EXOTIC files, make sure the "Show extracted files when complete" box is ticked and click "Extract". After extraction, a new window will open up showing the folder where the files are located, named after the version of the EXOTIC program (e.g. EXOTIC-0.45.3). 
 
 3. #### Installing EXOTIC
 
@@ -90,6 +90,4 @@ After installing EXOTIC itself, you may wish to install the SAOImageDS9 (Astrono
 ## Further Help and Support
 
 If you have any questions or comments, please feel free to reach out to us on Slack or email at [exoplanetwatch@jpl.nasa.gov](exoplanetwatch@jpl.nasa.gov)
-
-
 


### PR DESCRIPTION
Shows on how to download tar.gz from PyPi instead of zip file from GitHub, confirms EXOTIC compatibility with Ubuntu 18.04 LTS and 20.04 LTS, advises not to use Ubuntu on WSL2, shows how to fix missing tkinter.