### PR TITLE
Updated installers to validate and/or update network certs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ importlib-metadata>=3.6 ; python_version<='3.7'
 python_version
 astroalign~=2.0
 astropy>=4.0.1.post1
-astroquery~=0.4
+astroquery>=0.4.3,~=0.4
 barycorrpy~=0.3
 holoviews~=1.13
 LDTk~=1.4

--- a/run_exotic_mac.command
+++ b/run_exotic_mac.command
@@ -6,10 +6,14 @@ ver_py_min="3.6"
 ver_py_max="4.0"
 py_download="https://www.python.org/downloads/"
 pip_download="https://bootstrap.pypa.io/get-pip.py"
+test_url="https://exoplanetarchive.ipac.caltech.edu/TAP/sync"
+#test_url="https://exoplanetarchive.ipac.caltech.edu/TAP/sync?query=select%201%20from%20DUAL"
+cert_instructions="https://news.ycombinator.com/item?id=13626273"
 pip_instructions="https://pip.pypa.io/en/stable/installing/"
 py_instructions_linux="https://www.cyberciti.biz/faq/install-python-linux/"
 py_runner=""
 pip_runner=""
+test_result=""
 
 if echo "${0##*/}" | grep -q '_linux';
 then
@@ -48,9 +52,10 @@ done
 # exit if valid python not found
 if [[ -z "${py_runner}" ]];
 then
-    echo -e "ERROR: Incompatible or missing Python runtime. Please install\n" \
-            "       Python 3.6 or above. EXITING!"
-    echo -e "For more information, see ${py_download}. ...\n"
+    echo "ERROR: Incompatible or missing Python runtime. Please install"
+    echo "       Python 3.6 or above. EXITING!"
+    echo "For more information, see ${py_download}. ..."
+    echo
     exit 65
 fi
 # test for pip
@@ -84,9 +89,10 @@ then
     then
         wget "${pip_download}"
     else
-        echo -e "ERROR: Unable to download package manager. Please install\n" \
-                "       Pip for Python 3. EXITING!"
-        echo -e "For more information, see ${pip_instructions}. ...\n"
+        echo "ERROR: Unable to download package manager. Please install"
+        echo "       Pip for Python 3. EXITING!"
+        echo "For more information, see ${pip_instructions}. ..."
+        echo
         exit 65
     fi
     ${py_runner} get-pip.py
@@ -94,11 +100,23 @@ then
     # validate installation
     if ! ${pip_runner} --version ;
     then
-        echo -e "ERROR: Incompatible or missing package manager. Please install\n" \
-                "       Pip for Python 3. EXITING!"
-        echo -e "For more information, see ${pip_instructions}. ...\n"
+        echo "ERROR: Incompatible or missing package manager. Please install"
+        echo "       Pip for Python 3. EXITING!"
+        echo "For more information, see ${pip_instructions}. ..."
+        echo
         exit 65
     fi
+fi
+echo "INFO: Validating certificate store. ..."
+test_result=$(${py_runner} -u -c "import urllib.request; urllib.request.urlopen('${test_url}')" 2>&1)
+if grep -q 'CERTIFICATE_VERIFY_FAILED' <<< "${test_result}" ; 
+then 
+    echo "ERROR: Incompatible or missing network security certificates. Please install"
+    echo "       and configure the 'certifi' module from PyPi. EXITING!"
+    echo "       Example: Applications > Python 3.9 > Install Certificates.command"
+    echo "For more information, see ${cert_instructions}. ..."
+    echo
+    exit 65
 fi
 # exec commands using determinate pip
 echo "INFO: Installing EXOTIC build dependencies. ..."
@@ -107,4 +125,4 @@ ${pip_runner} install setuptools
 echo "INFO: Installing EXOTIC core. ..."
 ${pip_runner} install --upgrade exotic
 echo "INFO: Launching EXOTIC user interface. ..."
-bash -c "exotic-gui"
+bash -l -c "exotic-gui"

--- a/run_exotic_windows.bat
+++ b/run_exotic_windows.bat
@@ -2,5 +2,6 @@ ECHO OFF
 
 pip install wheel
 pip install setuptools
+pip install --upgrade python-certifi-win32
 pip install --upgrade exotic
 start cmd /k exotic-gui


### PR DESCRIPTION
Validate and/or update network certificate cache based on Python `certifi`. Users whose network fails to connect to a secure NEA URI will receive a warning message with instructions to perform CA store load/update steps, except in the case of Windows, which updates the Python cert cache with Windows' internal CA store.