### PR TITLE
Tests and documents `typecase_check()` function

### DIFF
--- a/exotic/tests/test_utils.py
+++ b/exotic/tests/test_utils.py
@@ -54,6 +54,36 @@ class TestInitParams:
         assert result.get("foo") is None
 
 
+class TestTypecastCheck:
+    """tests the `typecase_check()` function"""
+
+    @staticmethod
+    def _returns_four_point_oh(val_to_check):
+        assert 4.0 == typecast_check(float, val_to_check)
+
+    def test_checking_for_floats(self):
+        # NOTE: there are two usages (as of 2021-09-20) of the `typecast_check`
+        # function and both check for floats
+
+        # floats return floats
+        self._returns_four_point_oh(4.0)
+
+        # strings that look like floats return floats
+        self._returns_four_point_oh("4.0")
+
+        # ints can be converted to floats
+        self._returns_four_point_oh(4)
+
+        # strings that look like ints can be converted to floats
+        self._returns_four_point_oh("4")
+
+        # really nutty things like 4x10^0 are okay too
+        self._returns_four_point_oh(4e0)
+
+    def test_uncastable_value(self):
+        assert typecast_check(float, "foo") is False
+
+
 class TestRoundToTwo:
     """tests the round_to_2() function"""
 

--- a/exotic/utils.py
+++ b/exotic/utils.py
@@ -95,6 +95,21 @@ def init_params(comp, dict1, dict2):
 
 
 def typecast_check(type_, val):
+    """
+    Casts `val` into `type_`
+
+    Parameters
+    ----------
+    type_ : type
+        type to cast val. ex: float
+    val : any
+
+    Returns
+    -------
+    any
+        value casted to type_. ex 4.0. Returns False if val cannot be casted.
+    """
+
     try:
         return type_(val)
     except (ValueError, TypeError):


### PR DESCRIPTION
* covers the case of converting to floats only because
  usage indicates that's the only use
* A quibble, but does not actually `check` that a val is a type
  but rather casts the val _to the type_. Naming of this function
  could be improved in the future if desired.