### PR TITLE
Issue 892: Modified FWHM units for passbands and other values

### DIFF
--- a/exotic/output_files.py
+++ b/exotic/output_files.py
@@ -84,14 +84,12 @@ class OutputFiles:
                     f"#EXOPLANET_NAME={self.p_dict['pName']}\n"  # code yields
                     f"#BINNING={self.i_dict['pixel_bin']}\n"  # user input
                     f"#EXPOSURE_TIME={self.i_dict.get('exposure', -1)}\n"  # UI
-                    f"#FILTER-XC={dumps(filter_dict)}\n"
                     f"#COMP_STAR-XC={dumps(comp_star)}\n"
                     f"#NOTES={self.i_dict['notes']}\n"
                     "#DETREND_PARAMETERS=AIRMASS, AIRMASS CORRECTION FUNCTION\n"  # fixed
                     "#MEASUREMENT_TYPE=Rnflux\n"  # fixed
-                    f"#PRIORS-XC={dumps(priors_dict)}\n"  # code yields
-                    f"#RESULTS-XC={dumps(results_dict)}\n"  # code yields
                     f"#FILTER={self.i_dict['filter']}\n"
+                    f"#FILTER-XC={dumps(filter_dict)}\n"
                     f"#PRIORS=Period={round_to_2(self.p_dict['pPer'], self.p_dict['pPerUnc'])} +/- {round_to_2(self.p_dict['pPerUnc'])}"
                     f",a/R*={round_to_2(self.p_dict['aRs'], self.p_dict['aRsUnc'])} +/- {round_to_2(self.p_dict['aRsUnc'])}"
                     f",inc={round_to_2(self.p_dict['inc'], self.p_dict['incUnc'])} +/- {round_to_2(self.p_dict['incUnc'])}"
@@ -100,18 +98,21 @@ class OutputFiles:
                     f",u1={round_to_2(ld1[0], ld1[1])} +/- {round_to_2(ld1[1])}"
                     f",u2={round_to_2(ld2[0], ld2[1])} +/- {round_to_2(ld2[1])}"
                     f",u3={round_to_2(ld3[0], ld3[1])} +/- {round_to_2(ld3[1])}\n"
+                    f"#PRIORS-XC={dumps(priors_dict)}\n"  # code yields
                     f"#RESULTS=Tc={round_to_2(self.fit.parameters['tmid'], self.fit.errors['tmid'])} +/- {round_to_2(self.fit.errors['tmid'])}"
                     f",Rp/R*={round_to_2(self.fit.parameters['rprs'], self.fit.errors['rprs'])} +/- {round_to_2(self.fit.errors['rprs'])}"
                     f",a/R*={round_to_2(self.fit.parameters['ars'], self.fit.errors['ars'])} +/- {round_to_2(self.fit.errors['ars'])}"
                     f",Am1={round_to_2(self.fit.parameters['a1'], self.fit.errors['a1'])} +/- {round_to_2(self.fit.errors['a1'])}"
-                    f",Am2={round_to_2(self.fit.parameters['a2'], self.fit.errors['a2'])} +/- {round_to_2(self.fit.errors['a2'])}\n")
+                    f",Am2={round_to_2(self.fit.parameters['a2'], self.fit.errors['a2'])} +/- {round_to_2(self.fit.errors['a2'])}\n"
+                    f"#RESULTS-XC={dumps(results_dict)}\n")  # code yields
 
-            f.write("# EXOTIC is developed by Exoplanet Watch (exoplanets.nasa.gov/exoplanet-watch/), a citizen science "
-                    "project managed by NASA's Jet Propulsion Laboratory on behalf of NASA's Universe of Learning. "
-                    "This work is supported by NASA under award number NNX16AC65A to the "
-                    "Space Telescope Science Institute.\n"
-                    "# Use of this data is governed by the AAVSO Data Usage Guidelines: "
-                    "aavso.org/data-usage-guidelines\n")
+            f.write(
+                "# EXOTIC is developed by Exoplanet Watch (exoplanets.nasa.gov/exoplanet-watch/), a citizen science "
+                "project managed by NASA's Jet Propulsion Laboratory on behalf of NASA's Universe of Learning. "
+                "This work is supported by NASA under award number NNX16AC65A to the "
+                "Space Telescope Science Institute.\n"
+                "# Use of this data is governed by the AAVSO Data Usage Guidelines: "
+                "aavso.org/data-usage-guidelines\n")
 
             f.write("#DATE,DIFF,ERR,DETREND_1,DETREND_2\n")
             for aavsoC in range(0, len(self.fit.time)):
@@ -127,19 +128,21 @@ def aavso_dicts(planet_dict, fit, info_dict, durs, ld0, ld1, ld2, ld3):
     priors = {
         'Period': {
             'value': str(round_to_2(planet_dict['pPer'], planet_dict['pPerUnc'])),
-            'uncertainty': str(round_to_2(planet_dict['pPerUnc'])) if planet_dict['pPerUnc'] else planet_dict['pPerUnc']
+            'uncertainty': str(round_to_2(planet_dict['pPerUnc'])) if planet_dict['pPerUnc'] else planet_dict['pPerUnc'],
+            'units': "days"
         },
         'a/R*': {
             'value': str(round_to_2(planet_dict['aRs'], planet_dict['aRsUnc'])),
-            'uncertainty': str(round_to_2(planet_dict['aRsUnc'])) if planet_dict['aRsUnc'] else planet_dict['aRsUnc']
+            'uncertainty': str(round_to_2(planet_dict['aRsUnc'])) if planet_dict['aRsUnc'] else planet_dict['aRsUnc'],
         },
         'inc': {
             'value': str(round_to_2(planet_dict['inc'], planet_dict['incUnc'])),
-            'uncertainty': str(round_to_2(planet_dict['incUnc'])) if planet_dict['incUnc'] else planet_dict['incUnc']
+            'uncertainty': str(round_to_2(planet_dict['incUnc'])) if planet_dict['incUnc'] else planet_dict['incUnc'],
+            'units': "degrees"
         },
         'ecc': {
             'value': str(round_to_2(planet_dict['ecc'])),
-            'uncertainty': None
+            'uncertainty': None,
         },
         'u0': {
             'value': str(round_to_2(ld0[0], ld0[1])),
@@ -161,14 +164,15 @@ def aavso_dicts(planet_dict, fit, info_dict, durs, ld0, ld1, ld2, ld3):
 
     filter_type = {
         'name': info_dict['filter'],
-        'fwhm': [str(info_dict['wl_min']) if info_dict['wl_min'] else info_dict['wl_min'],
-                 str(info_dict['wl_max']) if info_dict['wl_max'] else info_dict['wl_max']]
+        'fwhm': [{'value': str(info_dict['wl_min']) if info_dict['wl_min'] else info_dict['wl_min'], 'units': "nm"},
+                 {'value': str(info_dict['wl_max']) if info_dict['wl_max'] else info_dict['wl_max'], 'units': "nm"}],
     }
 
     results = {
         'Tc': {
             'value': str(round_to_2(fit.parameters['tmid'], fit.errors['tmid'])),
-            'uncertainty': str(round_to_2(fit.errors['tmid']))
+            'uncertainty': str(round_to_2(fit.errors['tmid'])),
+            'units': "BJD_TDB"
         },
         'Rp/R*': {
             'value': str(round_to_2(fit.parameters['rprs'], fit.errors['rprs'])),
@@ -176,7 +180,7 @@ def aavso_dicts(planet_dict, fit, info_dict, durs, ld0, ld1, ld2, ld3):
         },
         'a/R*': {
             'value': str(round_to_2(fit.parameters['ars'], fit.errors['ars'])),
-            'uncertainty': str(round_to_2(fit.errors['ars']))
+            'uncertainty': str(round_to_2(fit.errors['ars'])),
         },
         'Am1': {
             'value': str(round_to_2(fit.parameters['a1'], fit.errors['a1'])),
@@ -188,7 +192,8 @@ def aavso_dicts(planet_dict, fit, info_dict, durs, ld0, ld1, ld2, ld3):
         },
         'Duration': {
             'value': str(round_to_2(mean(durs))),
-            'uncertainty': str(round_to_2(std(durs)))
+            'uncertainty': str(round_to_2(std(durs))),
+            'units': "days"
         }
     }
 


### PR DESCRIPTION
Following changes for AAVSO output file (please verify units if they exist on each value):

`#FILTER-XC={"name": "V", "fwhm": [{"value": "502.8", "units": "nm"}, {"value": "586.8", "units": "nm"}]}`

`#PRIORS-XC={"Period": {"value": "2.1500082", "uncertainty": "1.3e-07", "units": "days"}, "a/R*": {"value": "5.344", "uncertainty": "0.039"}, "inc": {"value": "88.98", "uncertainty": "0.76", "units": "degrees"}, "ecc": {"value": "0.16", "uncertainty": null}, "u0": {"value": "1.884", "uncertainty": "0.046"}, "u1": {"value": "-3.33", "uncertainty": "0.18"}, "u2": {"value": "3.92", "uncertainty": "0.24"}, "u3": {"value": "-1.48", "uncertainty": "0.1"}}`

`#RESULTS-XC={"Tc": {"value": "2458107.71385", "uncertainty": "0.00097", "units": "BJD_TDB"}, "Rp/R*": {"value": "0.1523", "uncertainty": "0.0033"}, "a/R*": {"value": "5.2", "uncertainty": "0.096"}, "Am1": {"value": "1.1588", "uncertainty": "0.0065"}, "Am2": {"value": "-0.1183", "uncertainty": "0.0023"}, "Duration": {"value": "0.13", "uncertainty": "0.0025", "units": "days"}}`

Closes #892 

