### PR TITLE
Issue 939: Clarifying input for Image Scale and removing numba temporarily

### DIFF
--- a/exotic/api/elca.py
+++ b/exotic/api/elca.py
@@ -42,7 +42,7 @@
 # ########################################################################### #
 
 import copy
-from numba import njit
+# from numba import njit
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.optimize import least_squares
@@ -288,7 +288,7 @@ class lc_fitter(object):
             model *= np.median(detrend)
             return -0.5 * np.sum(((self.data - model) / self.dataerr) ** 2)
 
-        @njit(fastmath=True)
+        # @njit(fastmath=True)
         def prior_transform(upars):
             # transform unit cube to prior volume
             return boundarray[:, 0] + bounddiff * upars

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -81,7 +81,7 @@ from logging.handlers import TimedRotatingFileHandler
 from matplotlib.animation import FuncAnimation
 # Pyplot imports
 import matplotlib.pyplot as plt
-from numba import njit
+# from numba import njit
 import numpy as np
 # photometry
 from photutils import CircularAperture
@@ -835,7 +835,7 @@ def get_pixel_scale(wcs_header, header, pixel_init):
         image_scale = f"Image scale in arcsecs/pixel: {pixel_init}"
     else:
         log_info("Not able to find Image Scale in the Image Header.")
-        image_scale_num = user_input("Please enter Image Scale (e.g., 5 arcsec/pixel): ", type_=float)
+        image_scale_num = user_input("Please enter Image Scale (units in arcsec/pixel): ", type_=float)
         image_scale = f"Image scale in arcsecs/pixel: {image_scale_num}"
     return image_scale
 
@@ -907,7 +907,6 @@ def find_target(target, hdufile, verbose=False):
     return pixcoord[0]
 
 
-@njit
 def gaussian_psf(x, y, x0, y0, a, sigx, sigy, rot, b):
     rx = (x - x0) * np.cos(rot) - (y - y0) * np.sin(rot)
     ry = (x - x0) * np.sin(rot) + (y - y0) * np.cos(rot)

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -835,7 +835,7 @@ def get_pixel_scale(wcs_header, header, pixel_init):
         image_scale = f"Image scale in arcsecs/pixel: {pixel_init}"
     else:
         log_info("Not able to find Image Scale in the Image Header.")
-        image_scale_num = user_input("Please enter Image Scale (units in arcsec/pixel): ", type_=float)
+        image_scale_num = user_input("Please enter Image Scale (arcsec/pixel): ", type_=float)
         image_scale = f"Image scale in arcsecs/pixel: {image_scale_num}"
     return image_scale
 


### PR DESCRIPTION
The following message changed from:
`Please enter Image Scale (e.g., 5 arcsec/pixel): `
to:
`Please enter Image Scale (arcsec/pixel): `

Please let me know if you have suggestions on what you'd think would better clarify a float input for the image scale. I modified it to match our planetary parameter entries.

Also, `numba` has been removed temporarily as it conflicts with `numpy` and needs to be updated anyways throughout the code. Will add back at a later time.