### PR TITLE
Issue 1006: EXOTIC & CITISENS Filter Unification 

### DIFF
--- a/exotic/api/filters.py
+++ b/exotic/api/filters.py
@@ -69,5 +69,5 @@ fwhm_alias = {
               "H NIR 1.6micron": "Near-Infrared H",
               "K NIR 2.2 micron": "Near-Infrared K",
               "K NIR 2.2micron": "Near-Infrared K",
-              "MObs CV": "Clear (unfiltered) reduced to V sequence",
+              "Clear (unfiltered) reduced to V sequence": "MObs CV"
 }

--- a/exotic/api/filters.py
+++ b/exotic/api/filters.py
@@ -69,5 +69,5 @@ fwhm_alias = {
               "H NIR 1.6micron": "Near-Infrared H",
               "K NIR 2.2 micron": "Near-Infrared K",
               "K NIR 2.2micron": "Near-Infrared K",
-              "Clear (unfiltered) reduced to V sequence": "MObs CV",
+              "MObs CV": "Clear (unfiltered) reduced to V sequence",
 }

--- a/exotic/api/filters.py
+++ b/exotic/api/filters.py
@@ -26,10 +26,17 @@ fwhm = {
         "Sloan z": {"name": "SZ", "desc": "Sloan z", "fwhm": ("841.2", "978.2")},
 
         # Stromgren
+        "Stromgren u": {"name": "STU", "desc": "Stromgren u", "fwhm": ("336.3", "367.7")},
+        "Stromgren v": {"name": "STV", "desc": "Stromgren v", "fwhm": ("418.5", "401.5")},
         "Stromgren b": {"name": "STB", "desc": "Stromgren b", "fwhm": ("459.55", "478.05")},
         "Stromgren y": {"name": "STY", "desc": "Stromgren y", "fwhm": ("536.7", "559.3")},
         "Stromgren Hbw": {"name": "STHBW", "desc": "Stromgren Hbw", "fwhm": ("481.5", "496.5")},
         "Stromgren Hbn": {"name": "STHBN", "desc": "Stromgren Hbn", "fwhm": ("487.5", "484.5")},
+
+        # Optec
+        "Optec Wing A": {"name": "MA", "desc": "Optec Wing A", "fwhm": ("706.5", "717.5")},
+        "Optec Wing B": {"name": "MB", "desc": "Optec Wing B", "fwhm": ("748.5", "759.5")},
+        "Optec Wing C": {"name": "MI", "desc": "Optec Wing C", "fwhm": ("1003.0", "1045.0")},
 
         # MObs Clear Filter; Source(s): Martin Fowler
         "MObs CV": {"name": "CV", "desc": "MObs CV", "fwhm": ("350.0", "850.0")},
@@ -37,11 +44,18 @@ fwhm = {
         # Astrodon CBB; Source(s): George Silvis; https://astrodon.com/products/astrodon-exo-planet-filter/
         "Astrodon ExoPlanet-BB": {"name": "CBB", "desc": "Astrodon ExoPlanet-BB", "fwhm": ("500.0", "1000.0")},
 
-        # LCO; Source(s): Kalee Tock and Michael Fitzgerald; https://lco.global/observatory/instruments/filters/
+        # LCO; Source(s): Kalee Tock and Michael Fitzgerald; 0.4m & 1.0m Telescopes; https://lco.global/observatory/instruments/filters/
+        "LCO Bessell U": {"name": "N/A", "desc": "LCO Bessell U", "fwhm": ("325.0", "375.0")},
         "LCO Bessell B": {"name": "N/A", "desc": "LCO Bessell B", "fwhm": ("391.6", "480.6")},
         "LCO Bessell V": {"name": "N/A", "desc": "LCO Bessell V", "fwhm": ("502.8", "586.8")},
+        "LCO Bessell R": {"name": "N/A", "desc": "LCO Bessell R", "fwhm": ("561.7", "719.7")},
+        "LCO Bessell I": {"name": "N/A", "desc": "LCO Bessell I", "fwhm": ("721.0", "875.0")},
+
         "LCO Pan-STARRS w": {"name": "N/A", "desc": "LCO Pan-STARRS w", "fwhm": ("404.2", "845.8")},
+        "LCO Pan-STARRS Y": {"name": "N/A", "desc": "LCO Pan-STARRS Y", "fwhm": ("948.0", "1060.0")},
         "LCO Pan-STARRS zs": {"name": "N/A", "desc": "LCO Pan-STARRS zs", "fwhm": ("818.0", "922.0")},
+
+        "LCO SDSS u'": {"name": "N/A", "desc": "LCO SDSS u'", "fwhm": ("325.5", "382.5")},
         "LCO SDSS g'": {"name": "N/A", "desc": "LCO SDSS g'", "fwhm": ("402.0", "552.0")},
         "LCO SDSS r'": {"name": "N/A", "desc": "LCO SDSS r'", "fwhm": ("552.0", "691.0")},
         "LCO SDSS i'": {"name": "N/A", "desc": "LCO SDSS i'", "fwhm": ("690.0", "819.0")},

--- a/exotic/api/filters.py
+++ b/exotic/api/filters.py
@@ -69,5 +69,5 @@ fwhm_alias = {
               "H NIR 1.6micron": "Near-Infrared H",
               "K NIR 2.2 micron": "Near-Infrared K",
               "K NIR 2.2micron": "Near-Infrared K",
-              "Clear (unfiltered) reduced to V sequence": "MObs CV"
+              "Clear (unfiltered) reduced to V sequence": "MObs CV",
 }

--- a/exotic/api/filters.py
+++ b/exotic/api/filters.py
@@ -27,7 +27,7 @@ fwhm = {
 
         # Stromgren
         "Stromgren u": {"name": "STU", "desc": "Stromgren u", "fwhm": ("336.3", "367.7")},
-        "Stromgren v": {"name": "STV", "desc": "Stromgren v", "fwhm": ("418.5", "401.5")},
+        "Stromgren v": {"name": "STV", "desc": "Stromgren v", "fwhm": ("401.5", "418.5")},
         "Stromgren b": {"name": "STB", "desc": "Stromgren b", "fwhm": ("459.55", "478.05")},
         "Stromgren y": {"name": "STY", "desc": "Stromgren y", "fwhm": ("536.7", "559.3")},
         "Stromgren Hbw": {"name": "STHBW", "desc": "Stromgren Hbw", "fwhm": ("481.5", "496.5")},

--- a/exotic/api/filters.py
+++ b/exotic/api/filters.py
@@ -1,9 +1,22 @@
-# Source for FWHM band wavelengths (units: nm): https://www.aavso.org/filters
-# Near-Infrared
+# Sources for FWHM band wavelengths are referenced below, respectively 
+# note that all below units default to nm
 fwhm = {
-        "J NIR 1.2 micron": {"name": "J", "desc": "J NIR 1.2micron", "fwhm": ("1040.0", "1360.0")},
-        "H NIR 1.6 micron": {"name": "H", "desc": "H NIR 1.6micron", "fwhm": ("1420.0", "1780.0")},
-        "K NIR 2.2 micron": {"name": "K", "desc": "K NIR 2.2micron", "fwhm": ("2015.0", "2385.0")},
+        # AAVSO, Source(s): AAVSO International Database; https://www.aavso.org/filters
+        # Johnson
+        "Johnson U": {"name": "U", "desc": "Johnson U", "fwhm": ("333.8", "398.8")},
+        "Johnson B": {"name": "B", "desc": "Johnson B", "fwhm": ("391.6", "480.6")},
+        "Johnson V": {"name": "V", "desc": "Johnson V", "fwhm": ("502.8", "586.8")},
+        "Johnson R": {"name": "RJ", "desc": "Johnson R", "fwhm": ("590.0", "810.0")},
+        "Johnson I": {"name": "IJ", "desc": "Johnson I", "fwhm": ("780.0", "1020.0")},
+
+        # Cousins
+        "Cousins R": {"name": "R", "desc": "Cousins R", "fwhm": ("561.7", "719.7")},
+        "Cousins I": {"name": "I", "desc": "Cousins I", "fwhm": ("721.0", "875.0")},
+
+        # Near-Infrared
+        "Near-Infrared J": {"name": "J", "desc": "Near-Infrared J", "fwhm": ("1040.0", "1360.0")},
+        "Near-Infrared H": {"name": "H", "desc": "Near-Infrared H", "fwhm": ("1420.0", "1780.0")},
+        "Near-Infrared K": {"name": "K", "desc": "Near-Infrared K", "fwhm": ("2015.0", "2385.0")},
 
         # Sloan
         "Sloan u": {"name": "SU", "desc": "Sloan u", "fwhm": ("321.8", "386.8")},
@@ -18,29 +31,29 @@ fwhm = {
         "Stromgren Hbw": {"name": "STHBW", "desc": "Stromgren Hbw", "fwhm": ("481.5", "496.5")},
         "Stromgren Hbn": {"name": "STHBN", "desc": "Stromgren Hbn", "fwhm": ("487.5", "484.5")},
 
-        # Johnson
-        "Johnson U": {"name": "U", "desc": "Johnson U", "fwhm": ("333.8", "398.8")},
-        "Johnson B": {"name": "B", "desc": "Johnson B", "fwhm": ("391.6", "480.6")},
-        "Johnson V": {"name": "V", "desc": "Johnson V", "fwhm": ("502.8", "586.8")},
-        "Johnson R": {"name": "RJ", "desc": "Johnson R", "fwhm": ("590.0", "810.0")},
-        "Johnson I": {"name": "IJ", "desc": "Johnson I", "fwhm": ("780.0", "1020.0")},
-
-        # Cousins
-        "Cousins R": {"name": "R", "desc": "Cousins R", "fwhm": ("561.7", "719.7")},
-        "Cousins I": {"name": "I", "desc": "Cousins I", "fwhm": ("721.0", "875.0")},
-
-        # MObs Clear Filter, Source: Martin Fowler
+        # MObs Clear Filter; Source(s): Martin Fowler
         "MObs CV": {"name": "CV", "desc": "MObs CV", "fwhm": ("350.0", "850.0")},
 
-        # Astrodon CBB: George Silvis: https://astrodon.com/products/astrodon-exo-planet-filter/
+        # Astrodon CBB; Source(s): George Silvis; https://astrodon.com/products/astrodon-exo-planet-filter/
         "Astrodon ExoPlanet-BB": {"name": "CBB", "desc": "Astrodon ExoPlanet-BB", "fwhm": ("500.0", "1000.0")},
 
-        # LCO, Source: Kalee Tock & Michael Fitzgerald, https://lco.global/observatory/instruments/filters/
+        # LCO; Source(s): Kalee Tock and Michael Fitzgerald; https://lco.global/observatory/instruments/filters/
         "LCO Bessell B": {"name": "N/A", "desc": "LCO Bessell B", "fwhm": ("391.6", "480.6")},
         "LCO Bessell V": {"name": "N/A", "desc": "LCO Bessell V", "fwhm": ("502.8", "586.8")},
         "LCO Pan-STARRS w": {"name": "N/A", "desc": "LCO Pan-STARRS w", "fwhm": ("404.2", "845.8")},
         "LCO Pan-STARRS zs": {"name": "N/A", "desc": "LCO Pan-STARRS zs", "fwhm": ("818.0", "922.0")},
         "LCO SDSS g'": {"name": "N/A", "desc": "LCO SDSS g'", "fwhm": ("402.0", "552.0")},
         "LCO SDSS r'": {"name": "N/A", "desc": "LCO SDSS r'", "fwhm": ("552.0", "691.0")},
-        "LCO SDSS i'": {"name": "N/A", "desc": "LCO SDSS i'", "fwhm": ("690.0", "819.0")}
+        "LCO SDSS i'": {"name": "N/A", "desc": "LCO SDSS i'", "fwhm": ("690.0", "819.0")},
+}
+
+# aliases to back-reference naming standard updates
+fwhm_alias = {
+              "J NIR 1.2 micron": "Near-Infrared J",
+              "J NIR 1.2micron": "Near-Infrared J",
+              "H NIR 1.6 micron": "Near-Infrared H",
+              "H NIR 1.6micron": "Near-Infrared H",
+              "K NIR 2.2 micron": "Near-Infrared K",
+              "K NIR 2.2micron": "Near-Infrared K",
+              "Clear (unfiltered) reduced to V sequence": "MObs CV",
 }

--- a/exotic/api/filters.py
+++ b/exotic/api/filters.py
@@ -1,34 +1,46 @@
 # Source for FWHM band wavelengths (units: nm): https://www.aavso.org/filters
 # Near-Infrared
-fwhm = {('J NIR 1.2micron', 'J'): (1040.00, 1360.00), ('H NIR 1.6micron', 'H'): (1420.00, 1780.00),
-        ('K NIR 2.2micron', 'K'): (2015.00, 2385.00),
+fwhm = {
+        "J NIR 1.2 micron": {"name": "J", "desc": "J NIR 1.2micron", "fwhm": ("1040.0", "1360.0")},
+        "H NIR 1.6 micron": {"name": "H", "desc": "H NIR 1.6micron", "fwhm": ("1420.0", "1780.0")},
+        "K NIR 2.2 micron": {"name": "K", "desc": "K NIR 2.2micron", "fwhm": ("2015.0", "2385.0")},
 
         # Sloan
-        ('Sloan u', 'SU'): (321.80, 386.80), ('Sloan g', 'SG'): (402.50, 551.50),
-        ('Sloan r', 'SR'): (553.10, 693.10), ('Sloan i', 'SI'): (697.50, 827.50),
-        ('Sloan z', 'SZ'): (841.20, 978.20),
+        "Sloan u": {"name": "SU", "desc": "Sloan u", "fwhm": ("321.8", "386.8")},
+        "Sloan g": {"name": "SG", "desc": "Sloan g", "fwhm": ("402.5", "551.5")},
+        "Sloan r": {"name": "SR", "desc": "Sloan r", "fwhm": ("553.1", "693.1")},
+        "Sloan i": {"name": "SI", "desc": "Sloan i", "fwhm": ("697.5", "827.5")},
+        "Sloan z": {"name": "SZ", "desc": "Sloan z", "fwhm": ("841.2", "978.2")},
 
         # Stromgren
-        ('Stromgren b', 'STB'): (459.55, 478.05), ('Stromgren y', 'STY'): (536.70, 559.30),
-        ('Stromgren Hbw', 'STHBW'): (481.50, 496.50), ('Stromgren Hbn', 'STHBN'): (487.50, 484.50),
+        "Stromgren b": {"name": "STB", "desc": "Stromgren b", "fwhm": ("459.55", "478.05")},
+        "Stromgren y": {"name": "STY", "desc": "Stromgren y", "fwhm": ("536.7", "559.3")},
+        "Stromgren Hbw": {"name": "STHBW", "desc": "Stromgren Hbw", "fwhm": ("481.5", "496.5")},
+        "Stromgren Hbn": {"name": "STHBN", "desc": "Stromgren Hbn", "fwhm": ("487.5", "484.5")},
 
         # Johnson
-        ('Johnson U', 'U'): (333.80, 398.80), ('Johnson B', 'B'): (391.60, 480.60),
-        ('Johnson V', 'V'): (502.80, 586.80), ('Johnson R', 'RJ'): (590.00, 810.00),
-        ('Johnson I', 'IJ'): (780.00, 1020.00),
+        "Johnson U": {"name": "U", "desc": "Johnson U", "fwhm": ("333.8", "398.8")},
+        "Johnson B": {"name": "B", "desc": "Johnson B", "fwhm": ("391.6", "480.6")},
+        "Johnson V": {"name": "V", "desc": "Johnson V", "fwhm": ("502.8", "586.8")},
+        "Johnson R": {"name": "RJ", "desc": "Johnson R", "fwhm": ("590.0", "810.0")},
+        "Johnson I": {"name": "IJ", "desc": "Johnson I", "fwhm": ("780.0", "1020.0")},
 
         # Cousins
-        ('Cousins R', 'R'): (561.70, 719.70), ('Cousins I', 'I'): (721.00, 875.00),
+        "Cousins R": {"name": "R", "desc": "Cousins R", "fwhm": ("561.7", "719.7")},
+        "Cousins I": {"name": "I", "desc": "Cousins I", "fwhm": ("721.0", "875.0")},
 
         # MObs Clear Filter, Source: Martin Fowler
-        ('MObs CV', 'CV'): (350.00, 850.00),
+        "MObs CV": {"name": "CV", "desc": "MObs CV", "fwhm": ("350.0", "850.0")},
 
         # Astrodon CBB: George Silvis: https://astrodon.com/products/astrodon-exo-planet-filter/
-        ('Astrodon ExoPlanet-BB', 'CBB'): (500.00, 1000.00),
+        "Astrodon ExoPlanet-BB": {"name": "CBB", "desc": "Astrodon ExoPlanet-BB", "fwhm": ("500.0", "1000.0")},
 
         # LCO, Source: Kalee Tock & Michael Fitzgerald, https://lco.global/observatory/instruments/filters/
-        ('LCO Bessell B', 'N/A'): (391.60, 480.60), ('LCO Bessell V', 'N/A'): (502.80, 586.80),
-        ('LCO Bessell U', 'N/A'): (325.0, 375.00), ('Harris B', 'N/A'): (377.75, 484.65),
-        ('LCO Pan-STARRS w', 'N/A'): (404.20, 845.80), ('LCO Pan-STARRS w', 'N/A'): (404.20, 845.80),
-        ('LCO Pan-STARRS zs', 'N/A'): (818.00, 922.00), ('LCO SDSS g\'', 'N/A'): (402.00, 552.00),
-        ('LCO SDSS r\'', 'N/A'): (552.00, 691.00), ('LCO SDSS i\'', 'N/A'): (690.00, 819.00)}
+        "LCO Bessell B": {"name": "N/A", "desc": "LCO Bessell B", "fwhm": ("391.6", "480.6")},
+        "LCO Bessell V": {"name": "N/A", "desc": "LCO Bessell V", "fwhm": ("502.8", "586.8")},
+        "LCO Pan-STARRS w": {"name": "N/A", "desc": "LCO Pan-STARRS w", "fwhm": ("404.2", "845.8")},
+        "LCO Pan-STARRS zs": {"name": "N/A", "desc": "LCO Pan-STARRS zs", "fwhm": ("818.0", "922.0")},
+        "LCO SDSS g'": {"name": "N/A", "desc": "LCO SDSS g'", "fwhm": ("402.0", "552.0")},
+        "LCO SDSS r'": {"name": "N/A", "desc": "LCO SDSS r'", "fwhm": ("552.0", "691.0")},
+        "LCO SDSS i'": {"name": "N/A", "desc": "LCO SDSS i'", "fwhm": ("690.0", "819.0")}
+}

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -482,6 +482,7 @@ class LimbDarkening:
         self.wl_max = wl_max
         self.fwhm = fwhm
         self.ld0 = self.ld1 = self.ld2 = self.ld3 = None
+        self.filter_desc = None
 
     def nonlinear_ld(self):
         if self.filter_type and not (self.wl_min or self.wl_max):
@@ -501,7 +502,7 @@ class LimbDarkening:
                     self._custom()
             else:
                 self._user_entered()
-        return self.ld0, self.ld1, self.ld2, self.ld3, self.filter_type, self.wl_min * 1000, self.wl_max * 1000
+        return self.ld0, self.ld1, self.ld2, self.ld3, self.filter_type, self.filter_desc, self.wl_min * 1000, self.wl_max * 1000
 
     def _standard_list(self):
         log_info("\n\n***************************")
@@ -509,19 +510,21 @@ class LimbDarkening:
         log_info("***************************")
         log_info("\nThe standard bands that are available for limb darkening parameters (https://www.aavso.org/filters)"
                  "\nas well as filters for MObs and LCO (0.4m telescope) datasets:\n")
-        for key, value in self.fwhm.items():
-            log_info(f"\t{key[1]}: {key[0]} - ({value[0]:.2f}-{value[1]:.2f}) nm")
+        for val in self.fwhm.values():
+            log_info(f"\u2022 {val['desc']}:\n\t-Abbreviation: {val['name']}"
+                     f"\n\t-FWHM: ({val['fwhm'][0]}-{val['fwhm'][1]}) nm")
 
     def _standard(self):
         while True:
             try:
                 if not self.filter_type:
                     self._standard_list()
-                    self.filter_type = user_input("\nPlease enter in the filter type (EX: Johnson V, V, STB, RJ):",
-                                                  type_=str)
-                for key, value in self.fwhm.items():
-                    if self.filter_type in (key[0], key[1]) and self.filter_type != 'N/A':
-                        self.filter_type = (key[0], key[1])
+                    self.filter_type = user_input("\nPlease enter in the Filter Name or Abbreviation "
+                                                  "(EX: Johnson V, V, STB, RJ): ", type_=str)
+                for val in self.fwhm.values():
+                    if self.filter_type.lower() in (val['desc'].lower(), val['name'].lower()) \
+                            and self.filter_type != 'N/A'.lower():
+                        self.filter_type = val['desc']
                         break
                 else:
                     raise KeyError
@@ -530,9 +533,10 @@ class LimbDarkening:
                 log_info("\nError: The entered filter is not in the provided list of standard filters.", error=True)
                 self.filter_type = None
 
-        self.wl_min = self.fwhm[self.filter_type][0]
-        self.wl_max = self.fwhm[self.filter_type][1]
-        self.filter_type = self.filter_type[1]
+        self.wl_min = float(self.fwhm[self.filter_type]['fwhm'][0])
+        self.wl_max = float(self.fwhm[self.filter_type]['fwhm'][1])
+        self.filter_desc = self.filter_type
+        self.filter_type = self.fwhm[self.filter_type]['name']
         self._calculate_ld()
 
     def _custom(self):
@@ -931,7 +935,7 @@ def fit_centroid(data, pos, psf_function=gaussian_psf, box=15, weightedcenter=Tr
     xv, yv = mesh_box(pos, box, maxx=data.shape[1], maxy=data.shape[0])
     subarray = data[yv, xv]
     init = [np.nanmax(subarray) - np.nanmin(subarray), 1, 1, 0, np.nanmin(subarray)]
-    
+
     # compute flux weighted centroid in x and y
     wx = np.sum(xv[0]*subarray.sum(0))/subarray.sum(0).sum()
     wy = np.sum(yv[:,0]*subarray.sum(1))/subarray.sum(1).sum()
@@ -1512,8 +1516,8 @@ def main():
                                logg=pDict['logg'], loggpos=pDict['loggUncPos'], loggneg=pDict['loggUncNeg'],
                                wl_min=exotic_infoDict['wl_min'], wl_max=exotic_infoDict['wl_max'],
                                filter_type=exotic_infoDict['filter'])
-        ld0, ld1, ld2, ld3, exotic_infoDict['filter'], exotic_infoDict['wl_min'], exotic_infoDict['wl_max'] = \
-            ld_obj.nonlinear_ld()
+        ld0, ld1, ld2, ld3, exotic_infoDict['filter'], exotic_infoDict['filter_desc'], exotic_infoDict['wl_min'], \
+            exotic_infoDict['wl_max'] = ld_obj.nonlinear_ld()
         ld = [ld0[0], ld1[0], ld2[0], ld3[0]]
 
         # check for Nans + Zeros
@@ -2029,7 +2033,7 @@ def main():
 
         # for k in myfit.bounds.keys():
         #     print(f"{myfit.parameters[k]:.6f} +- {myfit.errors[k]}")
-        
+
         if args.photometry:
             log_info("\nPhotometric Extraction Complete.")
             return

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -541,6 +541,7 @@ class LimbDarkening:
 
     def _custom(self):
         self.filter_type = 'N/A'
+        self.filter_desc = 'Custom'
         if not self.wl_min:
             self.wl_min = user_input("FWHM Minimum wavelength (nm):", type_=float)
         if not self.wl_max:
@@ -548,7 +549,8 @@ class LimbDarkening:
         self._calculate_ld()
 
     def _user_entered(self):
-        self.filter_type = user_input("\nEnter in your filter name:", type_=str)
+        self.filter_type = 'N/A'
+        self.filter_desc = 'Custom'
         ld_0 = user_input("\nEnter in your first nonlinear term:", type_=float)
         ld0_unc = user_input("Enter in your first nonlinear term uncertainty:", type_=float)
         ld_1 = user_input("\nEnter in your second nonlinear term:", type_=float)
@@ -559,7 +561,7 @@ class LimbDarkening:
         ld3_unc = user_input("Enter in your fourth nonlinear term uncertainty:", type_=float)
         self.ld0, self.ld1, self.ld2, self.ld3 = (ld_0, ld0_unc), (ld_1, ld1_unc), (ld_2, ld2_unc), (ld_3, ld3_unc)
 
-        log.debug(f"Filter name: {self.filter_type}")
+        log.debug(f"Filter Abbreviation: {self.filter_type}")
         log.debug(f"User-defined nonlinear limb-darkening coefficients: {ld_0}+/-{ld0_unc}, {ld_1}+/-{ld1_unc}, "
                   f"{ld_2}+/-{ld2_unc}, {ld_3}+/-{ld3_unc}")
 

--- a/exotic/inputs.py
+++ b/exotic/inputs.py
@@ -40,7 +40,7 @@ class Inputs:
         self.params = {
             'images': imaging_files, 'save': save_directory, 'aavso_num': obs_code, 'second_obs': second_obs_code,
             'date': obs_date, 'lat': latitude, 'long': longitude, 'elev': elevation, 'camera': camera,
-            'pixel_bin': pixel_bin, 'filter': filter_type, 'notes': obs_notes, 'plate_opt': plate_solution_opt,
+            'pixel_bin': pixel_bin, 'notes': obs_notes, 'plate_opt': plate_solution_opt,
             'tar_coords': target_star_coords, 'comp_stars': comparison_star_coords
         }
 
@@ -428,12 +428,6 @@ def pixel_bin(pix_bin):
     if not pix_bin:
         pix_bin = user_input("Please enter the pixel binning: ", type_=str)
     return pix_bin
-
-
-def filter_type(f_type):
-    if not f_type:
-        f_type = user_input("Please enter the filter name: ", type_=str)
-    return f_type
 
 
 def obs_notes(notes):

--- a/exotic/output_files.py
+++ b/exotic/output_files.py
@@ -164,6 +164,7 @@ def aavso_dicts(planet_dict, fit, info_dict, durs, ld0, ld1, ld2, ld3):
 
     filter_type = {
         'name': info_dict['filter'],
+        'desc': info_dict['filter_desc'],
         'fwhm': [{'value': str(info_dict['wl_min']) if info_dict['wl_min'] else info_dict['wl_min'], 'units': "nm"},
                  {'value': str(info_dict['wl_max']) if info_dict['wl_max'] else info_dict['wl_max'], 'units': "nm"}],
     }

--- a/inits.json
+++ b/inits.json
@@ -38,7 +38,7 @@
             "Obs. Elevation (meters)": 2616,
             "Camera Type (CCD or DSLR)": "CCD",
             "Pixel Binning": "1x1",
-            "Filter Name (aavso.org/filters)": "V",
+            "Filter Name (aavso.org/filters)": "CV",
             "Observing Notes": "Weather, seeing was nice.",
 
             "Plate Solution? (y/n)": "y",
@@ -77,8 +77,6 @@
             "Pre-reduced File:": "/sample-data/NormalizedFlux_HAT-P-32 b_December 17, 2017.txt",
             "Pre-reduced File Time Format (BJD_TDB, JD_UTC, MJD_UTC)": "BJD_TDB",
             "Pre-reduced File Units of Flux (flux, magnitude, millimagnitude)": "flux",
-
-
 
             "Filter Minimum Wavelength (nm)": null,
             "Filter Maximum Wavelength (nm)": null,


### PR DESCRIPTION
Modifying `filters.py` in EXOTIC to conform with CITISENS style (Issue #1006). Here is a subsection of how the AAVSO output file will appear as follows:

- If the filter exists within `filters.py` and is standard to AAVSO:
```
#FILTER=CV
#FILTER-XC={"name": "CV", "desc": "MObs CV", "fwhm": [{"value": "350.0", "units": "nm"}, {"value": "850.0", "units": "nm"}]}
```

- If the filter exists within `filters.py` but is not standard to AAVSO:
```
#FILTER=N/A
#FILTER-XC={"name": "N/A", "desc": "LCO SDSS i'", "fwhm": [{"value": "690.0", "units": "nm"}, {"value": "819.0", "units": "nm"}]}
```

- If the filter does not exists within `filters.py` and is not standard to AAVSO: 
```
#FILTER=N/A
#FILTER-XC={"name": "N/A", "desc": "Custom", "fwhm": [{"value": "300.0", "units": "nm"}, {"value": "400.0", "units": "nm"}]}
```