### PR TITLE
Issue 1017: Making list of comp stars entries more lenient

### DIFF
--- a/exotic/exotic_gui.py
+++ b/exotic/exotic_gui.py
@@ -836,8 +836,8 @@ def main():
                 input_data['elevation'] = float(elevation_entry.get())
                 input_data['pixscale'] = pixscale_entry.get()
                 if fitsortext.get() == 1:
-                    input_data['comppos'] = ast.literal_eval(comppos_entry.get())
-                    input_data['targetpos'] = ast.literal_eval(targetpos_entry.get())
+                    input_data['comppos'] = str(list(ast.literal_eval(comppos_entry.get())))
+                    input_data['targetpos'] = str(list(ast.literal_eval(targetpos_entry.get())))
 
                     if platesolve.get():
                         input_data['platesolve'] = 'y'

--- a/exotic/inputs.py
+++ b/exotic/inputs.py
@@ -3,6 +3,7 @@ import sys
 import json
 from pathlib import Path
 from astropy.io import fits
+import re
 
 try:
     from utils import user_input, init_params, typecast_check, \
@@ -459,9 +460,13 @@ def aavso_comp(opt):
                          type_=str, values=['y', 'n'])
     return opt
 
+
 def target_star_coords(coords, planet):
     if isinstance(coords, list) and len(coords) == 2:
         pass
+    elif isinstance(coords, str) and any(str.isdigit(x) for x in coords):
+        coords = ' '.join(re.sub('\D', ' ', coords).split()).split(' ')
+        coords = [int(i) for i in coords]
     else:
         coords = [user_input(f"\nPlease enter {planet}'s X Pixel Coordinate: ", type_=float),
                   user_input(f"\nPlease enter {planet}'s Y Pixel Coordinate: ", type_=float)]
@@ -473,6 +478,9 @@ def comparison_star_coords(comp_stars, rt_bool):
     if isinstance(comp_stars, list) and 1 <= len(comp_stars) <= 10 and \
             all(isinstance(star, list) for star in comp_stars):
         comp_stars = [star for star in comp_stars if star != []]
+    elif isinstance(comp_stars, str) and any(str.isdigit(x) for x in comp_stars):
+        comp_stars = ' '.join(re.sub('\D', ' ', comp_stars).split()).split(' ')
+        comp_stars = [[int(comp_stars[i]), int(comp_stars[i+1])] for i in range(0, len(comp_stars), 2)]
     else:
         comp_stars = []
 

--- a/inits.json
+++ b/inits.json
@@ -44,8 +44,8 @@
             "Plate Solution? (y/n)": "y",
             "Add Comparison Stars from AAVSO? (y/n)": "y",
 
-            "Target Star X & Y Pixel": [424, 286],
-            "Comparison Star(s) X & Y Pixel": [[465, 183], [512, 263], [], [], [], [], [], [], [], []]
+            "Target Star X & Y Pixel": "[424, 286]",
+            "Comparison Star(s) X & Y Pixel": "[[465, 183], [512, 263], [], [], [], [], [], [], [], []]"
     },
     "planetary_parameters": {
             "Target Star RA": "02:04:10",


### PR DESCRIPTION
Due to missing brackets, commas, possible additional symbols, etc., the JSON file would error when attempting to open. These changes should prevent that from happening in the future (hopefully) using regex. Some examples:

"[424 286" --> [424, 286]
"[[465      183], [512     263], [ , [], [], [], [],  []" --> [[465, 183], [512, 263]]

Closes issue #1017