### PR TITLE
Issue 949: Mid-Transit Uncertainty limited by Orbital Period

### DIFF
--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -1497,10 +1497,10 @@ def fit_lightcurve(times, tFlux, cFlux, airmass, ld, pDict):
     upper = prior['tmid'] + np.abs(25 * pDict['midTUnc'] + np.floor(arrayPhases).max() * 25 * pDict['pPerUnc'])
     lower = prior['tmid'] - np.abs(25 * pDict['midTUnc'] + np.floor(arrayPhases).max() * 25 * pDict['pPerUnc'])
 
-    if upper > prior['tmid'] + 0.5 * prior['per']:
-        upper = prior['tmid'] + 0.5 * prior['per']
-    if lower < prior['tmid'] - 0.5 * prior['per']:
-        lower = prior['tmid'] - 0.5 * prior['per']
+    if upper > prior['tmid'] + 0.25 * prior['per']:
+        upper = prior['tmid'] + 0.25 * prior['per']
+    if lower < prior['tmid'] - 0.25 * prior['per']:
+        lower = prior['tmid'] - 0.25 * prior['per']
 
     if np.floor(arrayPhases).max() - np.floor(arrayPhases).min() == 0:
         log_info("\nWarning:", warn=True)
@@ -2353,10 +2353,10 @@ def main():
         lower = pDict['midT'] - 35 * pDict['midTUnc'] + np.floor(phase).max() * (pDict['pPer'] - 35 * pDict['pPerUnc'])
 
         # clip bounds so they're within 1 orbit
-        if upper > prior['tmid'] + 0.5*prior['per']:
-            upper = prior['tmid'] + 0.5*prior['per']
-        if lower < prior['tmid'] - 0.5*prior['per']:
-            lower = prior['tmid'] - 0.5*prior['per']
+        if upper > prior['tmid'] + 0.25*prior['per']:
+            upper = prior['tmid'] + 0.25*prior['per']
+        if lower < prior['tmid'] - 0.25*prior['per']:
+            lower = prior['tmid'] - 0.25*prior['per']
 
         if np.floor(phase).max() - np.floor(phase).min() == 0:
             log_info("Error: Estimated mid-transit not in observation range (check priors or observation time)", error=True)

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -1497,6 +1497,11 @@ def fit_lightcurve(times, tFlux, cFlux, airmass, ld, pDict):
     upper = prior['tmid'] + np.abs(25 * pDict['midTUnc'] + np.floor(arrayPhases).max() * 25 * pDict['pPerUnc'])
     lower = prior['tmid'] - np.abs(25 * pDict['midTUnc'] + np.floor(arrayPhases).max() * 25 * pDict['pPerUnc'])
 
+    if upper > prior['tmid'] + 0.5 * prior['per']:
+        upper = prior['tmid'] + 0.5 * prior['per']
+    if lower < prior['tmid'] - 0.5 * prior['per']:
+        lower = prior['tmid'] - 0.5 * prior['per']
+
     if np.floor(arrayPhases).max() - np.floor(arrayPhases).min() == 0:
         log_info("\nWarning:", warn=True)
         log_info(" Estimated mid-transit time is not within the observations", warn=True)


### PR DESCRIPTION
Although it exists within the final fit ([here](https://github.com/rzellem/EXOTIC/blob/main/exotic/exotic.py#L2347-L2354)), I also added it within `fit_lightcurve()` when finding the optimal aperture/annulus size. Let me know if this change is necessary. 

Closes issue #949 nonetheless. 