### PR TITLE
Issue 1068: Saving dates in JD for Stellar Variability

### DIFF
--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -65,13 +65,13 @@ aa.PIXEL_TOL = 1
 import astropy.units as u
 from astropy.coordinates import SkyCoord, EarthLocation, AltAz
 from astropy.io import fits
-import astropy.time
+from astropy.time import Time
 from astropy.visualization import astropy_mpl_style
 from astropy.wcs import WCS, FITSFixedWarning
 from astroquery.simbad import Simbad
 from astroquery.gaia import Gaia
 # UTC to BJD converter import
-from barycorrpy import utc_tdb
+from barycorrpy.utc_tdb import JDUTC_to_BJDTDB
 # julian conversion imports
 import dateutil.parser as dup
 from pathlib import Path
@@ -179,70 +179,84 @@ def sigma_clip(ogdata, sigma=3, dt=21, po=2):
     return nanmask
 
 
-# Get Julian time, don't need to divide by 2 since assume mid-EXPOSURE
-# Find separate funciton in code that does julian conversion to BJD_TDB
-# Method that gets and returns the julian time of the observation
-def getJulianTime(header):
-    exptime_offset = 0
+def exp_offset(hdr, time_unit, exp):
+    """Returns exposure offset (in days) of more than 0 if headers reveals
+    the time was estimated at the start of the exposure rather than the middle
+    """
+    if 'start' in hdr.comments[time_unit]:
+        return exp / (2.0 * 60.0 * 60.0 * 24.0)
+    return 0.0
 
-    exp = header.get('EXPTIME')  # checking for variation in .fits header format
-    if exp:
-        exp = exp
+
+def ut_date(hdr, time_unit, exp):
+    """Converts the Gregorian Date to Julian Date from the header and returns it
+    along with the exposure offset
+    """
+    if time_unit == 'DATE-OBS':
+        greg_date = hdr[time_unit] if 'T' in hdr[time_unit] else f"{hdr[time_unit]}T{hdr['TIME-OBS']}"
     else:
-        exp = header.get('EXPOSURE')
+        greg_date = hdr[time_unit]
 
-    # Grab the BJD first
-    if 'BJD_TDB' in header:
-        julianTime = float(header['BJD_TDB'])
-        # If the time is from the beginning of the observation, then need to calculate mid-exposure time
-        if "start" in header.comments['BJD_TDB']:
-            exptime_offset = exp / 2. / 60. / 60. / 24.  # assume exptime is in seconds for now
-    elif "BJD_TBD" in header:  # looks like TheSky misspells BJD_TDB as BJD_TBD -> hardcoding this common misspelling
-        julianTime = float(header['BJD_TBD'])
-        # If the time is from the beginning of the observation, then need to calculate mid-exposure time
-        if "start" in header.comments['BJD_TBD']:
-            exptime_offset = exp / 2. / 60. / 60. / 24.  # assume exptime is in seconds for now
-    elif 'BJD' in header:
-        julianTime = float(header['BJD'])
-        # If the time is from the beginning of the observation, then need to calculate mid-exposure time
-        if "start" in header.comments['BJD']:
-            exptime_offset = exp / 2. / 60. / 60. / 24.  # assume exptime is in seconds for now
-    # then the DATE-OBS
-    elif "UT-OBS" in header:
-        gDateTime = header['UT-OBS']  # gets the gregorian date and time from the fits file header
-        dt = dup.parse(gDateTime)
-        atime = astropy.time.Time(dt)
-        julianTime = atime.jd
-        # If the time is from the beginning of the observation, then need to calculate mid-exposure time
-        if "start" in header.comments['UT-OBS']:
-            exptime_offset = exp / 2. / 60. / 60. / 24.  # assume exptime is in seconds for now
-    # Then Julian Date
-    elif 'JULIAN' in header:
-        julianTime = float(header['JULIAN'])
-        # If the time is from the beginning of the observation, then need to calculate mid-exposure time
-        if "start" in header.comments['JULIAN']:
-            exptime_offset = exp / 2. / 60. / 60. / 24.  # assume exptime is in seconds for now
-    # Then MJD-OBS last, as in the MicroObservatory headers, it has less precision
-    elif ("MJD-OBS" in header) and ("epoch" not in header.comments['MJD-OBS']):
-        julianTime = float(header["MJD-OBS"]) + 2400000.5
-        # If the time is from the beginning of the observation, then need to calculate mid-exposure time
-        if "start" in header.comments['MJD-OBS']:
-            exptime_offset = exp / 2. / 60. / 60. / 24.  # assume exptime is in seconds for now
-    else:
-        if 'T' in header['DATE-OBS']:
-            gDateTime = header['DATE-OBS']  # gets the gregorian date and time from the fits file header
-        else:
-            gDateTime = f"{header['DATE-OBS']}T{header['TIME-OBS']}"
+    dt = dup.parse(greg_date)
+    atime = Time(dt)
 
-        dt = dup.parse(gDateTime)
-        atime = astropy.time.Time(dt)
-        julianTime = atime.jd
-        # If the time is from the beginning of the observation, then need to calculate mid-exposure time
-        if "start" in header.comments['DATE-OBS']:
-            exptime_offset = exp / 2. / 60. / 60. / 24.  # assume exptime is in seconds for now
+    julian_time = atime.jd
+    offset = exp_offset(hdr, time_unit, exp)
 
-    # If the mid-exposure time is given in the fits header, then no offset is needed to calculate the mid-exposure time
-    return julianTime + exptime_offset
+    return julian_time + offset
+
+
+def julian_date(hdr, time_unit, exp):
+    """Returns Julian Date from the header along with the exposure offset.
+    If the image is taken from MicroObservatory (MJD-OBS),
+    add a timing offset (2400000.5) due to being less precise
+    """
+    time_offset = 2400000.5 if time_unit == 'MJD-OBS' else 0.0
+
+    julian_time = float(hdr[time_unit]) + time_offset
+    offset = exp_offset(hdr, time_unit, exp)
+
+    return julian_time + offset
+
+
+def img_time(hdr, var=False):
+    """Converts time from the header file to the Julian Date (JD, if needed)
+    and adds an exposure offset (if needed)
+
+    Parameters
+    ----------
+    hdr : astropy.io.fits
+        A header file that includes the time of when the image was taken
+    var : bool
+        Flag for if only JD is needed due to Stellar Variability code (ignore BJD)
+
+    Returns
+    -------
+    float
+        Time of when the image was taken in the JD with exposure offset
+    """
+    time_list = ['UT-OBS', 'JULIAN', 'MJD-OBS', 'DATE-OBS']
+
+    if not var:
+        time_list = ['BJD_TDB', 'BJD_TBD', 'BJD'] + time_list
+
+    exp = hdr.get('EXPTIME') if hdr.get('EXPTIME') else hdr.get('EXPOSURE')
+    time_dict = {
+        'BJD_TDB': julian_date,
+        'BJD_TBD': julian_date,
+        'BJD': julian_date,
+        'UT-OBS': ut_date,
+        'JULIAN': julian_date,
+        'MJD-OBS': julian_date,
+        'DATE-OBS': ut_date
+    }
+
+    hdr_time = next((time for time in time_list if time in hdr), None)
+
+    if hdr_time == 'MJD_OBS':
+        hdr_time = hdr_time if "epoch" not in hdr.comments[hdr_time] else 'DATE-OBS'
+
+    return time_dict[hdr_time](hdr, hdr_time, exp)
 
 
 # Method that gets and returns the airmass from the fits file (Really the Altitude)
@@ -259,7 +273,7 @@ def getAirMass(image_header, ra, dec, lati, longit, elevation):
         pointing = SkyCoord(str(ra) + " " + str(dec), unit=(u.deg, u.deg), frame='icrs')
 
         location = EarthLocation.from_geodetic(lat=lati * u.deg, lon=longit * u.deg, height=elevation)
-        atime = astropy.time.Time(getJulianTime(image_header), format='jd', scale='utc', location=location)
+        atime = Time(img_time(image_header), format='jd', scale='utc', location=location)
         pointingAltAz = pointing.transform_to(AltAz(obstime=atime, location=location))
         am = float(pointingAltAz.secz)
     return am
@@ -269,34 +283,30 @@ def getAirMass(image_header, ra, dec, lati, longit, elevation):
 def timeConvert(timeList, timeFormat, pDict, info_dict):
     # Perform appropriate conversion for each time format if needed
     if timeFormat == 'JD_UTC':
-        convertedTimes = utc_tdb.JDUTC_to_BJDTDB(timeList, ra=pDict['ra'], dec=pDict['dec'],
+        convertedTimes = JDUTC_to_BJDTDB(timeList, ra=pDict['ra'], dec=pDict['dec'],
                                                  lat=info_dict['lat'], longi=info_dict['long'], alt=info_dict['elev'])
     elif timeFormat == 'MJD_UTC':
-        convertedTimes = utc_tdb.JDUTC_to_BJDTDB(timeList + 2400000.5, ra=pDict['ra'], dec=pDict['dec'],
+        convertedTimes = JDUTC_to_BJDTDB(timeList + 2400000.5, ra=pDict['ra'], dec=pDict['dec'],
                                                  lat=info_dict['lat'], longi=info_dict['long'], alt=info_dict['elev'])
     timeList = convertedTimes[0]
 
     return timeList
 
 
-# Convert magnitude units to flux if pre-reduced file not in flux already
-def fluxConvert(fluxList, errorList, fluxFormat):
-    # If units already in flux, do nothing, perform appropriate conversions to flux otherwise
-    if fluxFormat == 'magnitude':
-        convertedPositiveErrors = 10. ** ((-1. * (fluxList + errorList)) / 2.5)
-        convertedNegativeErrors = 10. ** ((-1. * (fluxList - errorList)) / 2.5)
-        fluxList = 10. ** ((-1. * fluxList) / 2.5)
-    elif fluxFormat == 'millimagnitude':
-        convertedPositiveErrors = 10. ** ((-1. * ((fluxList + errorList) / 1000.)) / 2.5)
-        convertedNegativeErrors = 10. ** ((-1. * ((fluxList - errorList) / 1000.)) / 2.5)
-        fluxList = 10. ** (-1. * (fluxList / 1000.) / 2.5)
+def flux_conversion(fluxes, errors, flux_format):
+    """Converting differential magnitudes to fluxes and calculating its errors
+    """
+    conv = 1000.0 if flux_format == 'millimagnitude' else 1.0
 
-    # Use distance from mean of upper/lower error bounds to calculate new sigma values
-    positiveErrorDistance = abs(convertedPositiveErrors - fluxList)
-    negativeErrorDistance = abs(convertedNegativeErrors - fluxList)
-    meanErrorList = (positiveErrorDistance * negativeErrorDistance) ** 0.5
+    pos_err = 10.0 ** (-0.4 * ((fluxes + errors) / conv))
+    neg_err = 10.0 ** (-0.4 * ((fluxes - errors) / conv))
+    fluxes = 10.0 ** (-0.4 * (fluxes / conv))
 
-    return fluxList, meanErrorList
+    pos_err_dist = abs(pos_err - fluxes)
+    neg_err_dist = abs(neg_err - fluxes)
+    mean_errors = (pos_err_dist * neg_err_dist) ** 0.5
+
+    return fluxes, mean_errors
 
 
 # Check for difference between NEA and initialization file
@@ -973,7 +983,7 @@ def find_target(target, hdufile, verbose=False):
         pm_ra_cosdec=result['pmra'][0] * u.mas / u.yr,
         pm_dec=result['pmdec'][0] * u.mas / u.yr,
         frame="icrs",
-        obstime=astropy.time.Time("2000-1-1T00:00:00")
+        obstime=Time("2000-1-1T00:00:00")
     )
 
     hdu = fits.open(hdufile)[0]
@@ -987,7 +997,7 @@ def find_target(target, hdufile, verbose=False):
     if len(dateobs.split('-')) == 4:
         dateobs = '-'.join(dateobs.split('-')[:-1])
 
-    t = astropy.time.Time(dateobs, format='isot', scale='utc')
+    t = Time(dateobs, format='isot', scale='utc')
     coordpm = coord.apply_space_motion(new_obstime=t)
 
     # wcs coordinate translation
@@ -1134,16 +1144,14 @@ def skybg_phot(data, xc, yc, r=10, dr=5, ptol=99, debug=False):
 
 def jd_bjd(non_bjd, p_dict, info_dict):
     try:
-        resultos = utc_tdb.JDUTC_to_BJDTDB(non_bjd, ra=p_dict['ra'], dec=p_dict['dec'],
+        resultos = JDUTC_to_BJDTDB(non_bjd, ra=p_dict['ra'], dec=p_dict['dec'],
                                            lat=info_dict['lat'], longi=info_dict['long'],
                                            alt=info_dict['elev'])
         goodTimes = resultos[0]
     except:
-        targetloc = astropy.coordinates.SkyCoord(p_dict['ra'], p_dict['dec'], unit=(u.deg, u.deg),
-                                                 frame='icrs')
-        obsloc = astropy.coordinates.EarthLocation(lat=info_dict['lat'], lon=info_dict['long'],
-                                                   height=info_dict['elev'])
-        timesToConvert = astropy.time.Time(non_bjd, format='jd', scale='utc', location=obsloc)
+        targetloc = SkyCoord(p_dict['ra'], p_dict['dec'], unit=(u.deg, u.deg), frame='icrs')
+        obsloc = EarthLocation(lat=info_dict['lat'], lon=info_dict['long'], height=info_dict['elev'])
+        timesToConvert = Time(non_bjd, format='jd', scale='utc', location=obsloc)
         ltt_bary = timesToConvert.light_travel_time(targetloc)
         time_barycentre = timesToConvert.tdb + ltt_bary
         goodTimes = time_barycentre.value
@@ -1151,10 +1159,10 @@ def jd_bjd(non_bjd, p_dict, info_dict):
     return goodTimes
 
 
-def variability_calc(ref_flux, ckey, lmfit, good_times):
-    intx_times = np.intersect1d(np.array(good_times), np.array(ref_flux[ckey]['myfit'].time))
+def variability_calc(ref_flux, ckey, lmfit, times):
+    intx_times = np.intersect1d(np.array(times), np.array(ref_flux[ckey]['myfit'].time))
     comp_mask = [True if i in intx_times else False for i in ref_flux[ckey]['myfit'].time]
-    tar_mask = [True if i in intx_times else False for i in good_times]
+    tar_mask = [True if i in intx_times else False for i in times]
 
     OOT = (np.array(ref_flux[ckey]['myfit'].transit)[comp_mask] == 1)  # possibly fix this to intersect both
     OOT_scatter = np.std((np.array(ref_flux[ckey]['myfit'].data) / np.array(ref_flux[ckey]['myfit'].airmass_model))[comp_mask])
@@ -1176,7 +1184,7 @@ def variability_calc(ref_flux, ckey, lmfit, good_times):
     return comp_dict, OOT
 
 
-def find_comp(ref_flux, lmfit, good_times, ref_comp, comp_stars, vsp_comp_stars, save):
+def find_comp(ref_flux, lmfit, times, ref_comp, comp_stars, vsp_comp_stars, save):
     labels = {}
 
     for key, value in vsp_comp_stars.items():
@@ -1191,7 +1199,7 @@ def find_comp(ref_flux, lmfit, good_times, ref_comp, comp_stars, vsp_comp_stars,
             i = 0
         if k >= len(markerlist):
             k = 0
-        ref_comp[ckey], OOT = variability_calc(ref_flux, ckey, lmfit, good_times)
+        ref_comp[ckey], OOT = variability_calc(ref_flux, ckey, lmfit, times)
         plt.errorbar(ref_comp[ckey]['times'][OOT], ref_comp[ckey]['res'], fmt=markerlist[k], color=colorlist[i],
                      label=f"{labels[tuple(ref_flux[ckey]['xy'])]}")
         k += 1
@@ -1206,24 +1214,15 @@ def find_comp(ref_flux, lmfit, good_times, ref_comp, comp_stars, vsp_comp_stars,
     return comp_stars[min_std], ref_comp
 
 
-def stellar_variability(ref_flux, lmfit, comp_stars, id, vsp_comp_stars, vsp_ind, best_comp, save, s_name, bjd_inc,
-                        p_dict, info_dict):
+def stellar_variability(ref_flux, lmfit, times, comp_stars, id, vsp_comp_stars, vsp_ind, best_comp, save, s_name):
     ref_comp = {}
     idx_list, vsp_params = [], []
 
-    if not bjd_inc:
-        good_times = jd_bjd(lmfit.time, p_dict, info_dict)
-
-        for ckey in ref_flux.keys():
-            ref_flux[ckey]['myfit'].time = jd_bjd(ref_flux[ckey]['myfit'].time, p_dict, info_dict)
-    else:
-        good_times = lmfit.time
-
     if best_comp is None or (best_comp not in vsp_ind):
-        comp_xy, ref_comp = find_comp(ref_flux, lmfit, good_times, ref_comp, comp_stars, vsp_comp_stars, save)
+        comp_xy, ref_comp = find_comp(ref_flux, lmfit, times, ref_comp, comp_stars, vsp_comp_stars, save)
     else:
         comp_xy = comp_stars[best_comp]
-        ref_comp[best_comp], OOT = variability_calc(ref_flux, best_comp, lmfit, good_times)
+        ref_comp[best_comp], OOT = variability_calc(ref_flux, best_comp, lmfit, times)
 
     comp_star = [vsp_comp_stars[ckey] for ckey in vsp_comp_stars.keys() if comp_xy == vsp_comp_stars[ckey]['xy']][0]
 
@@ -1231,7 +1230,7 @@ def stellar_variability(ref_flux, lmfit, comp_stars, id, vsp_comp_stars, vsp_ind
 
     comp_flux, ckey = [(ref_flux[ckey], ckey) for ckey in ref_flux.keys() if comp_xy == ref_flux[ckey]['xy']][0]
 
-    intx_times = np.intersect1d(np.array(good_times), np.array(comp_flux['myfit'].time))
+    intx_times = np.intersect1d(np.array(times), np.array(comp_flux['myfit'].time))
     comp_mask = [True if i in intx_times else False for i in comp_flux['myfit'].time]
     OOT = (np.array(comp_flux['myfit'].transit)[comp_mask] == 1)
 
@@ -1324,7 +1323,7 @@ def realTimeReduce(i, target_name, info_dict, ax):
         while header['NAXIS'] == 0:
             extension += 1
             header = fits.getheader(filename=ifile, ext=extension)
-        times.append(getJulianTime(header))
+        times.append(img_time(header))
 
     si = np.argsort(times)
     inputfiles = np.array(inputfiles)[si]
@@ -1376,7 +1375,7 @@ def realTimeReduce(i, target_name, info_dict, ax):
             image_header = hdul[extension].header
 
         # TIME
-        timeVal = getJulianTime(image_header)
+        timeVal = img_time(image_header)
         timeList.append(timeVal)
 
         # IMAGES
@@ -1795,19 +1794,20 @@ def main():
             # FLUX DATA EXTRACTION AND MANIPULATION
             #########################################
 
-            timeList, airMassList, exptimes = [], [], []
+            airMassList, exptimes = [], []
 
             inputfiles = corruption_check(exotic_infoDict['images'])
 
             # time sort images
-            times = []
-            for ifile in inputfiles:
+            times, vsp_times = [], []
+            for file in inputfiles:
                 extension = 0
-                header = fits.getheader(filename=ifile, ext=extension)
+                header = fits.getheader(filename=file, ext=extension)
                 while header['NAXIS'] == 0:
                     extension += 1
-                    header = fits.getheader(filename=ifile, ext=extension)
-                times.append(getJulianTime(header))
+                    header = fits.getheader(filename=file, ext=extension)
+                times.append(img_time(header))
+                vsp_times.append(img_time(header, var=True))
 
             # checks for MOBS data
             mobs_header = fits.getheader(filename=inputfiles[0], ext=0)
@@ -1819,6 +1819,9 @@ def main():
                         exotic_infoDict['second_obs'] = "MOBS"
 
             si = np.argsort(times)
+            times = np.array(times)[si]
+            vsp_times = np.array(vsp_times)[si]
+
             inputfiles = np.array(inputfiles)[si]
             exotic_UIprevTPX = exotic_infoDict['tar_coords'][0]
             exotic_UIprevTPY = exotic_infoDict['tar_coords'][1]
@@ -1910,10 +1913,6 @@ def main():
                 while image_header["NAXIS"] == 0:
                     extension += 1
                     image_header = hdul[extension].header
-
-                # TIME
-                timeVal = getJulianTime(image_header)
-                timeList.append(timeVal)
 
                 # AIRMASS
                 airMass = getAirMass(image_header, pDict['ra'], pDict['dec'], exotic_infoDict['lat'], exotic_infoDict['long'],
@@ -2026,10 +2025,9 @@ def main():
                 log_info("No images to fit...check reference image for alignment (first image of sequence)")
 
             # convert to numpy arrays
-            times = np.array(timeList)[~badmask]
+            times = times[~badmask]
             airmass = np.array(airMassList)[~badmask]
             psf_data["target"] = psf_data["target"][~badmask]
-            si = np.argsort(times)
 
             exotic_infoDict['exposure'] = exp_time_med(exptimes)
 
@@ -2223,7 +2221,13 @@ def main():
             # Take the BJD times from the image headers
             if "BJD_TDB" in image_header or "BJD" in image_header or "BJD_TBD" in image_header:
                 goodTimes = nonBJDTimes
-                bjd_inc = True
+
+                index_list = np.intersect1d(times, nonBJDTimes)
+                good_vsp_times = [vsp_times[i] for i in index_list]
+                for key, val in ref_flux_dict.items():
+                    index_list = np.intersect1d(ref_flux_dict[key]['myfit'].time, times)
+                    ref_flux_dict[key]['time'] = [vsp_times[i] for i in index_list]
+
             # If not in there, then convert all the final times into BJD - using astropy alone
             else:
                 log_info("No Barycentric Julian Dates (BJDs) in Image Headers for standardizing time format. "
@@ -2233,7 +2237,8 @@ def main():
                 animate_toggle(True)
                 goodTimes = jd_bjd(nonBJDTimes, pDict, exotic_infoDict)
                 animate_toggle()
-                bjd_inc = False
+
+                good_vsp_times = nonBJDTimes
 
             # sigma clip
             si = np.argsort(goodTimes)
@@ -2273,7 +2278,7 @@ def main():
 
             # TODO: convert the exoplanet archive mid transit time to bjd - need to take into account observatory location listed in Exoplanet Archive
             # tMidtoC = astropy.time.Time(timeMidTransit, format='jd', scale='utc')
-            # forPhaseResult = utc_tdb.JDUTC_to_BJDTDB(tMidtoC, ra=raDeg, dec=decDeg, lat=lati, longi=longit, alt=2000)
+            # forPhaseResult = JDUTC_to_BJDTDB(tMidtoC, ra=raDeg, dec=decDeg, lat=lati, longi=longit, alt=2000)
             # bjdMidTOld = float(forPhaseResult[0])
             # bjdMidTOld = pDict['midT']
 
@@ -2293,13 +2298,13 @@ def main():
 
             if vsp_comp_stars:
                 if not bestCompStar:
-                    vsp_params = stellar_variability(ref_flux_dict, bestlmfit, compStarList, chart_id, vsp_comp_stars,
-                                                     vsp_num, bestCompStar, exotic_infoDict['save'], pDict['sName'], bjd_inc,
-                                                     pDict, exotic_infoDict)
+                    vsp_params = stellar_variability(ref_flux_dict, bestlmfit, good_vsp_times, compStarList, chart_id,
+                                                     vsp_comp_stars, vsp_num, bestCompStar, exotic_infoDict['save'],
+                                                     pDict['sName'])
                 else:
-                    vsp_params = stellar_variability(ref_flux_dict, bestlmfit, compStarList, chart_id, vsp_comp_stars,
-                                                     vsp_num, bestCompStar - 1, exotic_infoDict['save'], pDict['sName'],
-                                                     bjd_inc, pDict, exotic_infoDict)
+                    vsp_params = stellar_variability(ref_flux_dict, bestlmfit, good_vsp_times, compStarList, chart_id,
+                                                     vsp_comp_stars, vsp_num, bestCompStar - 1, exotic_infoDict['save'],
+                                                     pDict['sName'])
 
             log_info("\n\nOutput File Saved")
         else:
@@ -2327,7 +2332,7 @@ def main():
 
             if exotic_infoDict['file_units'] != 'flux':
                 print("check flux convert")
-                goodFluxes, goodNormUnc = fluxConvert(goodFluxes, goodNormUnc, exotic_infoDict['file_units'])
+                goodFluxes, goodNormUnc = flux_conversion(goodFluxes, goodNormUnc, exotic_infoDict['file_units'])
 
         # for k in myfit.bounds.keys():
         #     print(f"{myfit.parameters[k]:.6f} +- {myfit.errors[k]}")

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -241,22 +241,15 @@ def img_time(hdr, var=False):
         time_list = ['BJD_TDB', 'BJD_TBD', 'BJD'] + time_list
 
     exp = hdr.get('EXPTIME') if hdr.get('EXPTIME') else hdr.get('EXPOSURE')
-    time_dict = {
-        'BJD_TDB': julian_date,
-        'BJD_TBD': julian_date,
-        'BJD': julian_date,
-        'UT-OBS': ut_date,
-        'JULIAN': julian_date,
-        'MJD-OBS': julian_date,
-        'DATE-OBS': ut_date
-    }
 
     hdr_time = next((time for time in time_list if time in hdr), None)
 
     if hdr_time == 'MJD_OBS':
         hdr_time = hdr_time if "epoch" not in hdr.comments[hdr_time] else 'DATE-OBS'
 
-    return time_dict[hdr_time](hdr, hdr_time, exp)
+    if hdr_time in ['UT-OBS', 'DATE-OBS']:
+        return ut_date(hdr, hdr_time, exp)
+    return julian_date(hdr, hdr_time, exp)
 
 
 # Method that gets and returns the airmass from the fits file (Really the Altitude)

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -225,7 +225,7 @@ def img_time(hdr, var=False):
 
     Parameters
     ----------
-    hdr : astropy.io.fits
+    hdr : astropy.io.fits.header.Header
         A header file that includes the time of when the image was taken
     var : bool
         Flag for if only JD is needed due to Stellar Variability code (ignore BJD)
@@ -240,7 +240,7 @@ def img_time(hdr, var=False):
     if not var:
         time_list = ['BJD_TDB', 'BJD_TBD', 'BJD'] + time_list
 
-    exp = hdr.get('EXPTIME') if hdr.get('EXPTIME') else hdr.get('EXPOSURE')
+    exp = hdr['EXPTIME'] if 'EXPTIME' in hdr else hdr['EXPOSURE']
 
     hdr_time = next((time for time in time_list if time in hdr), None)
 

--- a/exotic/exotic_gui.py
+++ b/exotic/exotic_gui.py
@@ -791,7 +791,9 @@ def main():
 
                 aavsocomp = tk.BooleanVar()
                 aavsocomp_check = tk.Checkbutton(root, text="Add Comparison Stars Automatically"
-                                                            "\nfrom AAVSO's VSP API",
+                                                            "\nfrom AAVSO's VSP API for Stellar"
+                                                            "\nVariability Reduction \n"
+                                                            "(must have plate solution)",
                                                   variable=aavsocomp, onvalue=True, offvalue=False, justify=tk.LEFT)
                 aavsocomp_check.grid(row=i, column=j, sticky=tk.W, pady=2)
                 i += 1

--- a/exotic/output_files.py
+++ b/exotic/output_files.py
@@ -144,7 +144,7 @@ class VSPOutputFiles:
                     f"#OBSCODE={self.i_dict['aavso_num']}\n"  # UI
                     f"#SOFTWARE=EXOTIC v{__version__}\n"  # fixed
                     "#DELIM=,\n"  # fixed
-                    "#DATE_TYPE=BJD_TDB\n"  # fixed
+                    "#DATE_TYPE=JD\n"  # fixed
                     f"#OBSTYPE={self.i_dict['camera']}\n")
             f.write(
                 "# EXOTIC is developed by Exoplanet Watch (exoplanets.nasa.gov/exoplanet-watch/), a citizen science "

--- a/exotic/plots.py
+++ b/exotic/plots.py
@@ -205,8 +205,8 @@ def plot_final_lightcurve(fit, high_res, targ_name, save, date):
 
     Path(save).mkdir(parents=True, exist_ok=True)
     try:
-        f.savefig(Path(save) / "temp" / f"FinalLightCurve_{targ_name}_{date}.png", bbox_inches="tight")
-        f.savefig(Path(save) / "temp" / f"FinalLightCurve_{targ_name}_{date}.pdf", bbox_inches="tight")
+        f.savefig(Path(save) / f"FinalLightCurve_{targ_name}_{date}.png", bbox_inches="tight")
+        f.savefig(Path(save) / f"FinalLightCurve_{targ_name}_{date}.pdf", bbox_inches="tight")
     except Exception:
         pass
     plt.close()


### PR DESCRIPTION
Previously, the code saved time in BJD instead of AAVSO's standard for JD. Converted it to JD instead. 

**Please** review the changes carefully, I heavily modified the functions dealing with time and even flux (just for organization). Trying to document each function in a standard format so that we can get an idea of what each does. 

Closes issue #1068 