### PR TITLE
Fix ./run_exotic_linux.sh to handle Ubuntu not putting ~/.local/bin on PATH

### DIFF
--- a/run_exotic_linux.sh
+++ b/run_exotic_linux.sh
@@ -128,12 +128,17 @@ ${pip_runner} install --upgrade exotic
 echo "INFO: Launching EXOTIC user interface. ..."
 if ${pip_runner} freeze | grep -iq 'exotic' ;
 then
-    # Ubuntu doesn't put this on path...
-    if [ -x ~/.local/bin/exotic-gui ] ;
+    if hash exotic-gui > /dev/null ;
     then
-        bash -c "~/.local/bin/exotic-gui"
-    else
         bash -c "exotic-gui"
+    # Ubuntu doesn't put this on path...
+    else
+        if [ -x ~/.local/bin/exotic-gui ] ;
+        then
+            bash -c "~/.local/bin/exotic-gui"
+        else
+            echo "ERROR: cannot find exotic-gui"
+        fi
     fi
 else
     echo "ERROR: Unable to launch EXOTIC, installation failed. Please verify installation"

--- a/run_exotic_linux.sh
+++ b/run_exotic_linux.sh
@@ -128,7 +128,13 @@ ${pip_runner} install --upgrade exotic
 echo "INFO: Launching EXOTIC user interface. ..."
 if ${pip_runner} freeze | grep -iq 'exotic' ;
 then
-    bash -c "exotic-gui"
+    # Ubuntu doesn't put this on path...
+    if [ -x ~/.local/bin/exotic-gui ] ;
+    then
+        bash -c "~/.local/bin/exotic-gui"
+    else
+        bash -c "exotic-gui"
+    fi
 else
     echo "ERROR: Unable to launch EXOTIC, installation failed. Please verify installation"
     echo "       steps reported on screen or open a support ticket at: "


### PR DESCRIPTION
This is a check and fallback to handle the fact that, oddly, Ubuntu installations do not put the ~/.local/bin directory (where command_scripts get built and installed, by default) on the PATH - more correctly, if you are running a non-login terminal on Ubuntu (e.g. a terminal window on a graphical shell login), it is not on the path; but if a bash is used for a login shell (e.g. ssh into the system), it is (because it is added by .profile, which is only used for login shells...).

In any case, this uses the bash built-in command, hash, to check if exotic-gui is on the path (nominal path), and runs as before if that is true; else, it checks for existence of the command in ~/.local/bin and runs it from there, if so.