### PR TITLE
Avoid code duplication

### DIFF
--- a/exotic/api/nea.py
+++ b/exotic/api/nea.py
@@ -307,9 +307,7 @@ class NASAExoplanetArchive:
                 rprserr = ((rperr / rs) ** 2 + (-rp * rserr / rs ** 2) ** 2) ** 0.5
                 rprs = rp / rs
 
-        if data['pl_ratdor'] is None:
-            data['pl_ratdor'] = pow((data['pl_orbper'] / 365) ** 2, 1 / 3) / (data['st_rad'] * R_SUN.to('au')).value
-        elif data['pl_ratdor'] < 1 or np.isnan(data['pl_ratdor']):
+        if data['pl_ratdor'] is None or data['pl_ratdor'] < 1 or np.isnan(data['pl_ratdor']):
             data['pl_ratdor'] = pow((data['pl_orbper'] / 365) ** 2, 1 / 3) / (data['st_rad'] * R_SUN.to('au')).value
         else:
             print("WARNING: a/Rs can not be estimated from Nasa Exoplanet Archive. Please use an inits file instead.")

--- a/exotic/api/nea.py
+++ b/exotic/api/nea.py
@@ -307,8 +307,8 @@ class NASAExoplanetArchive:
                 rprserr = ((rperr / rs) ** 2 + (-rp * rserr / rs ** 2) ** 2) ** 0.5
                 rprs = rp / rs
 
-        if data['pl_ratdor'] is None or data['pl_ratdor'] < 1 or np.isnan(data['pl_ratdor']):
-            data['pl_ratdor'] = pow((data['pl_orbper'] / 365) ** 2, 1 / 3) / (data['st_rad'] * R_SUN.to('au')).value
+        if data['pl_ratdor'] is None or np.isnan(data['pl_ratdor']) or data['pl_ratdor'] < 1.:
+            data['pl_ratdor'] = pow((data['pl_orbper'] / 365.) ** 2, 1. / 3.) / (data['st_rad'] * R_SUN.to('au')).value
         else:
             print("WARNING: a/Rs can not be estimated from Nasa Exoplanet Archive. Please use an inits file instead.")
 


### PR DESCRIPTION
Since "or" is a short-circuit operator (https://docs.python.org/3.9/library/stdtypes.html#boolean-operations-and-or-not), the condition can be simplified to avoid code duplication.