### PR TITLE
Make random seed settable to make model solving run-to-run consistent

### DIFF
--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -1686,6 +1686,10 @@ def main():
         else:
             pDict = userpDict
             CandidatePlanetBool = False
+        # Seed random number generator (for run to run consistency)
+        if exotic_infoDict['random_seed']:
+            log_info(f"Setting random number seed to {exotic_infoDict['random_seed']}")
+            np.random.seed(exotic_infoDict['random_seed'])
 
         if fitsortext == 1:
             # Only do the dark correction if user selects this option

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -57,6 +57,7 @@ warnings.simplefilter('ignore', category=AstropyDeprecationWarning)
 
 # standard imports
 import argparse
+import hashlib
 # Image alignment import
 import astroalign as aa
 aa.PIXEL_TOL = 1
@@ -1689,7 +1690,10 @@ def main():
         # Seed random number generator (for run to run consistency)
         if exotic_infoDict['random_seed']:
             log_info(f"Setting random number seed to {exotic_infoDict['random_seed']}")
-            np.random.seed(exotic_infoDict['random_seed'])
+        else:
+            exotic_infoDict['random_seed'] = int.from_bytes(hashlib.sha256(f"{pDict['pName']}:{pDict['midT']}".encode()).digest()[0:4], byteorder='little')
+            log_info(f"Generated random number seed {exotic_infoDict['random_seed']}")
+        np.random.seed(exotic_infoDict['random_seed'])
 
         if fitsortext == 1:
             # Only do the dark correction if user selects this option

--- a/exotic/inputs.py
+++ b/exotic/inputs.py
@@ -36,7 +36,8 @@ class Inputs:
             'elev': None, 'camera': None, 'pixel_bin': None, 'filter': None, 'notes': None,
             'plate_opt': None, 'aavso_comp': None, 'tar_coords': None, 'comp_stars': None,
             'prered_file': None, 'file_units': None, 'file_time': None, 'phot_comp_star': None,
-            'wl_min': None, 'wl_max': None, 'pixel_scale': None, 'exposure': None
+            'wl_min': None, 'wl_max': None, 'pixel_scale': None, 'exposure': None,
+            'random_seed': None
         }
         self.params = {
             'images': imaging_files, 'save': save_directory, 'aavso_num': obs_code, 'second_obs': second_obs_code,
@@ -188,6 +189,7 @@ class Inputs:
             'wl_min': 'Filter Minimum Wavelength (nm)', 'wl_max': 'Filter Maximum Wavelength (nm)',
             'pixel_scale': ('Image Scale (Ex: 5.21 arcsecs/pixel)', 'Pixel Scale (Ex: 5.21 arcsecs/pixel)'),
             'exposure': 'Exposure Time (s)',
+            'random_seed': 'Random Seed'
         }
 
         self.info_dict = init_params(user_info, self.info_dict, data['user_info'])


### PR DESCRIPTION
The model fitting code, which makes appropriate use of 'Monte Carlo' techniques when producing solutions, has one problem (which can be a concern for both testing and for research purposes): the random number generator is not seeded in a controlled fashion, which results in the pseudorandom number sequence used being inconsistent from run to run, even for unchanged data and code. On data sets I've worked with, this does tend to result in minor (but not insignificant) changes from run to run.

Tapping into techniques I've seen on other data processing systems, the most simple solution to this is to have the seed for the random number generator be either explicitly controlled, or deterministically generated from the some consistent elements of the source data. To this end, this PR adds a 'Random seed' optional attribute to the 'options' section of inits.json (for the first case), while generating a high entropy but repeatable seed (based on a SHA-256 hash of the "Planet Name" and the "Published Mid-Transit Time (BJD-UTC)" fields).

Based on your thoughts on this, we could adjust things to make this more optional (that is, only pin the random seed when the 'Random seed' field is set, with no generated version), but I suspect repeated run consistency is probably a good default behavior (IMHO).