### PR TITLE
Handle dropped/bad frames cleanly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,5 @@ eaConf.json
 get-pip.py
 newfits.fits
 eaConf.json
+exotic.log.*
+pl_names.json

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -2055,7 +2055,6 @@ def main():
             # loop over comp stars
             for j in range(len(compStarList)):
                 ckey = f"comp{j + 1}"
-                #done above -psf_data[ckey] = psf_data[ckey][~badmask]
 
                 cFlux = 2 * np.pi * psf_data[ckey][:, 2] * psf_data[ckey][:, 3] * psf_data[ckey][:, 4]
                 myfit, tFlux1, cFlux1 = fit_lightcurve(times, tFlux, cFlux, airmass, ld, pDict)

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -1010,10 +1010,6 @@ def mesh_box(pos, box, maxx=0, maxy=0):
 def fit_centroid(data, pos, psf_function=gaussian_psf, box=15, weightedcenter=True):
     # get sub field in image
     xv, yv = mesh_box(pos, box, maxx=data.shape[1], maxy=data.shape[0])
-    # Handle null subfield - cannot solve
-    if xv.shape[0] == 0 or yv.shape[0] == 0:
-        log_info(f"Warning: empty subfield for fit_centroid at {np.round(pos, 2)}", warn=True)
-        return np.empty(7) * np.nan
     subarray = data[yv, xv]
     try:
         init = [np.nanmax(subarray) - np.nanmin(subarray), 1, 1, 0, np.nanmin(subarray)]

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -1010,13 +1010,13 @@ def mesh_box(pos, box, maxx=0, maxy=0):
 def fit_centroid(data, pos, psf_function=gaussian_psf, box=15, weightedcenter=True):
     # get sub field in image
     xv, yv = mesh_box(pos, box, maxx=data.shape[1], maxy=data.shape[0])
-    # Handle null subfield - cannot solve
-    if xv.shape[0] == 0 or yv.shape[0] == 0:
+    subarray = data[yv, xv]
+    try:
+        init = [np.nanmax(subarray) - np.nanmin(subarray), 1, 1, 0, np.nanmin(subarray)]
+    except ValueError as ve:
+        # Handle null subfield - cannot solve
         log_info(f"Warning: empty subfield for fit_centroid at {np.round(pos, 2)}", warn=True)
         return np.empty(7) * np.nan
-    subarray = data[yv, xv]
-    init = [np.nanmax(subarray) - np.nanmin(subarray), 1, 1, 0, np.nanmin(subarray)]
-
     # compute flux weighted centroid in x and y
     wx = np.sum(xv[0]*subarray.sum(0))/subarray.sum(0).sum()
     wy = np.sum(yv[:,0]*subarray.sum(1))/subarray.sum(1).sum()

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -1010,6 +1010,10 @@ def mesh_box(pos, box, maxx=0, maxy=0):
 def fit_centroid(data, pos, psf_function=gaussian_psf, box=15, weightedcenter=True):
     # get sub field in image
     xv, yv = mesh_box(pos, box, maxx=data.shape[1], maxy=data.shape[0])
+    # Handle null subfield - cannot solve
+    if xv.shape[0] == 0 or yv.shape[0] == 0:
+        log_info(f"Warning: empty subfield for fit_centroid at {np.round(pos, 2)}", warn=True)
+        return np.empty(7) * np.nan
     subarray = data[yv, xv]
     try:
         init = [np.nanmax(subarray) - np.nanmin(subarray), 1, 1, 0, np.nanmin(subarray)]


### PR DESCRIPTION
This PR attempts to deal with some issues that can occur in less-than-ideal data sets. Specifically,

Cases where a frame fails to solve properly
Cases where a frame solves properly, but turns out to have the centroid of the target correspond to an 'out of frame' location (that is, failure to have solvable centroid)
Cases where a companion star turns out to be out of frame, resulting in centroid being unsolvable
In all cases, the main goal is to assure that the various generated per-frame data correctly have their per-frame indexes properly adjusted - since there are extensive assumptions that the per-frame index arrays are logically consistent, and of consistent length. Specifically,

aper_data[X][i], where [i] is frame index
psf_data[X][i], where [i] is frame index
airmass[i], where [i] is frame index
times[i], where [i] is frame index
This alignment was being done partially, but not completely, and this resulted in various processing problems during model fitting.