### PR TITLE
Add support for demosaic, for sake of color scopes/cameras (e.g. Unistellar)

### DIFF
--- a/exotic/exotic_gui.py
+++ b/exotic/exotic_gui.py
@@ -1418,8 +1418,8 @@ def main():
                         "Target Star X & Y Pixel": (input_data['targetpos']),
                         "Comparison Star(s) X & Y Pixel": (input_data['comppos']),
                         
-                        "Demosaic Format": (input_data["demosaic_fmt"]),
-                        "Demosaic Output": (input_data["demosaic_out"]),
+                        "Demosaic Format": null, # TODO add GUI input for these
+                        "Demosaic Output": null
                     }
 
                     if flats_dir.folder_path == 'null':

--- a/exotic/exotic_gui.py
+++ b/exotic/exotic_gui.py
@@ -362,7 +362,7 @@ def main():
                 "Target Star RA": "Must be in HH:MM:SS sexagesimal format.",
                 "Target Star DEC": "Must be in +/-DD:MM:SS sexagesimal format with correct sign at the beginning (+ or -).",
                 'Demosaic Format': "Optional control for handling Bayer pattern color images - to use, provide Bayer color patttern of your camera (RGGB, BGGR, GRBG, GBRG) - null (no color processing) is default",
-                'Demosaic Output': "Select how to process color data (gray for grayscale, red or green or blue for single color channel, blueblock for grayscale without blue, [ R, G, B ] for custom weights for mixing colors.  green is default"
+                'Demosaic Output': "Select how to process color data (gray for grayscale, red or green or blue for single color channel, blueblock for grayscale without blue, [ R, G, B ] for custom weights for mixing colors.  green is default",
                 "Formatting of null": "Due to the file being a .json, null is case sensitive and must be spelled as shown.",
                 "Decimal Format": "Leading zero must be included when appropriate (Ex: 0.32, .32 or 00.32 causes errors.)."
             }

--- a/exotic/exotic_gui.py
+++ b/exotic/exotic_gui.py
@@ -361,6 +361,8 @@ def main():
                 "Custom Filter": "To use a custom filter, enter in the FWHM in optional_info.",
                 "Target Star RA": "Must be in HH:MM:SS sexagesimal format.",
                 "Target Star DEC": "Must be in +/-DD:MM:SS sexagesimal format with correct sign at the beginning (+ or -).",
+                'Demosaic Format': "Optional control for handling Bayer pattern color images - to use, provide Bayer color patttern of your camera (RGGB, BGGR, GRBG, GBRG) - null (no color processing) is default",
+                'Demosaic Output': "Select how to process color data (gray for grayscale, red or green or blue for single color channel, blueblock for grayscale without blue, [ R, G, B ] for custom weights for mixing colors.  green is default"
                 "Formatting of null": "Due to the file being a .json, null is case sensitive and must be spelled as shown.",
                 "Decimal Format": "Leading zero must be included when appropriate (Ex: 0.32, .32 or 00.32 causes errors.)."
             }

--- a/exotic/exotic_gui.py
+++ b/exotic/exotic_gui.py
@@ -361,8 +361,8 @@ def main():
                 "Custom Filter": "To use a custom filter, enter in the FWHM in optional_info.",
                 "Target Star RA": "Must be in HH:MM:SS sexagesimal format.",
                 "Target Star DEC": "Must be in +/-DD:MM:SS sexagesimal format with correct sign at the beginning (+ or -).",
-                'Demosaic Format': "Optional control for handling Bayer pattern color images - to use, provide Bayer color patttern of your camera (RGGB, BGGR, GRBG, GBRG) - null (no color processing) is default",
-                'Demosaic Output': "Select how to process color data (gray for grayscale, red or green or blue for single color channel, blueblock for grayscale without blue, [ R, G, B ] for custom weights for mixing colors.  green is default",
+                "Demosaic Format": "Optional control for handling Bayer pattern color images - to use, provide Bayer color patttern of your camera (RGGB, BGGR, GRBG, GBRG) - null (no color processing) is default",
+                "Demosaic Output": "Select how to process color data (gray for grayscale, red or green or blue for single color channel, blueblock for grayscale without blue, [ R, G, B ] for custom weights for mixing colors.  green is default",
                 "Formatting of null": "Due to the file being a .json, null is case sensitive and must be spelled as shown.",
                 "Decimal Format": "Leading zero must be included when appropriate (Ex: 0.32, .32 or 00.32 causes errors.)."
             }
@@ -1414,7 +1414,10 @@ def main():
                         "Add Comparison Stars from AAVSO? (y/n)": input_data['aavso_comp'],
 
                         "Target Star X & Y Pixel": (input_data['targetpos']),
-                        "Comparison Star(s) X & Y Pixel": (input_data['comppos'])
+                        "Comparison Star(s) X & Y Pixel": (input_data['comppos']),
+                        
+                        "Demosaic Format": (input_data["demosaic_fmt"]),
+                        "Demosaic Output": (input_data["demosaic_out"]),
                     }
 
                     if flats_dir.folder_path == 'null':

--- a/exotic/exotic_gui.py
+++ b/exotic/exotic_gui.py
@@ -370,7 +370,9 @@ def main():
                 "Directory with FITS files": FITS_dir.folder_path,
 
                 "Target Star X & Y Pixel": input_data['targetpos'],
-                "Comparison Star(s) X & Y Pixel": [input_data['comppos']]
+                "Comparison Star(s) X & Y Pixel": [input_data['comppos']],
+                "Demosaic Format": null, # TODO add GUI input for these
+                "Demosaic Output": null
             }
             new_inits['planetary_parameters'] = {
                 "Planet Name": input_data['pName'],

--- a/exotic/exotic_gui.py
+++ b/exotic/exotic_gui.py
@@ -1383,6 +1383,8 @@ def main():
                 "Custom Filter": "To use a custom filter, enter in the FWHM in optional_info.",
                 "Target Star RA": "Must be in HH:MM:SS sexagesimal format.",
                 "Target Star DEC": "Must be in +/-DD:MM:SS sexagesimal format with correct sign at the beginning (+ or -).",
+                "Demosaic Format": "Optional control for handling Bayer pattern color images - to use, provide Bayer color patttern of your camera (RGGB, BGGR, GRBG, GBRG) - null (no color processing) is default",
+                "Demosaic Output": "Select how to process color data (gray for grayscale, red or green or blue for single color channel, blueblock for grayscale without blue, [ R, G, B ] for custom weights for mixing colors.  green is default",
                 "Formatting of null": "Due to the file being a .json, null is case sensitive and must be spelled as shown.",
                 "Decimal Format": "Leading zero must be included when appropriate (Ex: 0.32, .32 or 00.32 causes errors.)."
             }

--- a/exotic/inputs.py
+++ b/exotic/inputs.py
@@ -156,7 +156,7 @@ class Inputs:
         user_info = {
             'images': 'Directory with FITS files', 'save': 'Directory to Save Plots',
             'flats': 'Directory of Flats', 'darks': 'Directory of Darks', 'biases': 'Directory of Biases',
-            'demosaic_fmt': 'Demosaic format', 'demosaic_out': 'Demosaic output',
+            'demosaic_fmt': 'Demosaic Format', 'demosaic_out': 'Demosaic Output',
             'aavso_num': ('AAVSO Observer Code (N/A if none)', 'AAVSO Observer Code (blank if none)'),
             'second_obs': ('Secondary Observer Codes (N/A if none)', 'Secondary Observer Codes (blank if none)'),
             'date': 'Observation date', 'lat': 'Obs. Latitude', 'long': 'Obs. Longitude',

--- a/exotic/inputs.py
+++ b/exotic/inputs.py
@@ -37,7 +37,7 @@ class Inputs:
             'plate_opt': None, 'aavso_comp': None, 'tar_coords': None, 'comp_stars': None,
             'prered_file': None, 'file_units': None, 'file_time': None, 'phot_comp_star': None,
             'wl_min': None, 'wl_max': None, 'pixel_scale': None, 'exposure': None,
-            'random_seed': None
+            'random_seed': None, "demosaic_fmt": None, "demosaic_out": None
         }
         self.params = {
             'images': imaging_files, 'save': save_directory, 'aavso_num': obs_code, 'second_obs': second_obs_code,
@@ -75,6 +75,8 @@ class Inputs:
                                        self.info_dict['biases'], self.init_opt)
                 if not planet:
                     planet = planet_name(planet)
+                self.info_dict['demosaic_fmt'], self.info_dict['demosaic_out'] = \
+                    demosaic_settings(self.info_dict['demosaic_fmt'], self.info_dict['demosaic_out'], self.init_opt)
 
         return self.info_dict, planet
 
@@ -153,6 +155,7 @@ class Inputs:
         user_info = {
             'images': 'Directory with FITS files', 'save': 'Directory to Save Plots',
             'flats': 'Directory of Flats', 'darks': 'Directory of Darks', 'biases': 'Directory of Biases',
+            'demosaic_fmt': 'Demosaic format', 'demosaic_out': 'Demosaic output',
             'aavso_num': ('AAVSO Observer Code (N/A if none)', 'AAVSO Observer Code (blank if none)'),
             'second_obs': ('Secondary Observer Codes (N/A if none)', 'Secondary Observer Codes (blank if none)'),
             'date': 'Observation date', 'lat': 'Obs. Latitude', 'long': 'Obs. Longitude',
@@ -299,6 +302,18 @@ def check_calibration(directory, image_type):
         return check_imaging_files(directory, image_type)
     return None
 
+def demosaic_settings(demosaic_fmt, demosaic_out, init):
+    opt = None
+    if init == 'n':
+        opt = user_input("\nAre images color and require demosaicing? (y/n): ",
+            type_=str, values=['y', 'n'])
+    if opt == 'y':
+        if not demosaic_fmt:
+            demosaic_fmt = user_input(f"\nWhat is Bayer pattern for camera? (RGGB, BGGR, GRBG, GBRG): ", type_=str, values=['rggb', 'bggr', 'grbg', 'gbrg'])
+            demosaic_fmt = demosaic_fmt.upper()
+        if not demosaic_out:
+            demosaic_out = user_input(f"\nWhat color channel should be processed? (gray, red, green, blue, blueblock): ", type_=str, values=['gray', 'red', 'green', 'blue', 'blueblock'])
+    return demosaic_fmt, demosaic_out
 
 def planet_name(planet):
     if not planet:

--- a/exotic/inputs.py
+++ b/exotic/inputs.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 from astropy.io import fits
 import re
+import numpy as np
 
 try:
     from utils import user_input, init_params, typecast_check, \
@@ -312,7 +313,13 @@ def demosaic_settings(demosaic_fmt, demosaic_out, init):
             demosaic_fmt = user_input(f"\nWhat is Bayer pattern for camera? (RGGB, BGGR, GRBG, GBRG): ", type_=str, values=['rggb', 'bggr', 'grbg', 'gbrg'])
             demosaic_fmt = demosaic_fmt.upper()
         if not demosaic_out:
-            demosaic_out = user_input(f"\nWhat color channel should be processed? (gray, red, green, blue, blueblock): ", type_=str, values=['gray', 'red', 'green', 'blue', 'blueblock'])
+            demosaic_out = user_input(f"\nWhat color channel should be processed? (gray, red, green, blue, blueblock, custom): ", type_=str, values=['gray', 'red', 'green', 'blue', 'blueblock', 'custom'])
+        if demosaic_out == 'custom':
+            demosaic_red = user_input("\nWhat weight for red channel (0.0-1.0)?", type=float)
+            demosaic_green = user_input("\nWhat weight for green channel (0.0-1.0)?", type=float)
+            demosaic_blue = user_input("\nWhat weight for blue channel (0.0-1.0)?", type=float)
+            demosaic_out = [ demosaic_red, demosaic_green, demosaic_blue ]
+
     return demosaic_fmt, demosaic_out
 
 def planet_name(planet):

--- a/inits.json
+++ b/inits.json
@@ -19,6 +19,8 @@
             "Custom Filter": "To use a custom filter, enter in the FWHM in optional_info.",
             "Target Star RA": "Must be in HH:MM:SS sexagesimal format.",
             "Target Star DEC": "Must be in +/-DD:MM:SS sexagesimal format with correct sign at the beginning (+ or -).",
+            "Demosaic Format": "Optional control for handling Bayer pattern color images - to use, provide Bayer color patttern of your camera (RGGB, BGGR, GRBG, GBRG) - null (no color processing) is default",
+            "Demosaic Output": "Select how to process color data (gray for grayscale, red or green or blue for single color channel, blueblock for grayscale without blue, [ R, G, B ] for custom weights for mixing colors.  green is default",
             "Formatting of null": "Due to the file being a .json, null is case sensitive and must be spelled as shown.",
             "Decimal Format": "Leading zero must be included when appropriate (Ex: 0.32, .32 or 00.32 causes errors.)."
     },
@@ -45,7 +47,10 @@
             "Add Comparison Stars from AAVSO? (y/n)": "y",
 
             "Target Star X & Y Pixel": "[424, 286]",
-            "Comparison Star(s) X & Y Pixel": "[[465, 183], [512, 263], [], [], [], [], [], [], [], []]"
+            "Comparison Star(s) X & Y Pixel": "[[465, 183], [512, 263], [], [], [], [], [], [], [], []]",
+
+            "Demosaic Format": null,
+            "Demosaic Output": null
     },
     "planetary_parameters": {
             "Target Star RA": "02:04:10",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ astroalign~=2.4
 astropy>=4.3
 astroquery~=0.4
 barycorrpy~=0.4
+colour_demosaicing~=0.2.3
 dynesty~=1.2.3;platform_system=='Windows'
 holoviews~=1.16
 importlib-metadata>=3.6;python_version<='3.7'


### PR DESCRIPTION
This PR adds two new optional settings to inits.json:

- "Demosaic format" (dictionary symbol demosaic_fmt) - if defined and non-null, this specifies the Bayer pattern of the images in the FITS files.  Valid values include 'RGGB', 'BGGR', 'GRBG', 'GBRG'.  RGGB is likely most common pattern for color imagers.  Demosaicing is done using a bilinear interpolation - I opted for this, not because it is the best method, but because I suspected that its simple linear interpolation was less likely to result in added luminocity 'noise' from things like edge detection that visually superior methods use.
- "Demosaic output" (dictionary symbol demosaic_out) - this specifies the disposition of the demosaiced data, since we don't leverage having 3 primaries.   Values include the following:
   - [ weightR, weightG, weightB ]: this allows a custom camera-specific set of weights to be applied, allowing the output to be determined by R * weightRed + G * weightG + B * weightB.  Weights are normalized before use, such that weightR+weightG+weightB = 1.0.
   - 'gray' : converts the RGB to a gray scale, using standard luminosity method (Y = 0.299 * R + 0.587 * G + 0.114 * B) as implemented by rgb2gray function in skimage library.   Equivalent to [ 0.299, 0.587, 0.144 ].
   - 'red', 'green', 'blue': this pulls just the corresponding channel.  This may be worth considering for, say, chromaticity testing (but I need to investigate some false positive targets to see if this actually works in practice).   Equivalent to [ 1, 0, 0 ], [ 0, 1, 0 ], and [ 0, 0, 1 ], respectively.
   - 'blueblock': this is a variant of 'gray', except it is done after zeroing the blue color channel.  Cannot say how effective this is, but it seems an interesting experiment.  Equivalent to [ 0.299, 0.587, 0.0 ].
   
If not specified, 'green' is used,  corresponding to the AAVSO recommendations I've seen for DSLR and color CMOS.  This avoids the issue of relative color weight variability, while leveraging the 50% of the pixels that are green - and the curve for green on most color cameras is often similar to a V filter, although CG is probably most appropriate.

The processing results in an identically sized and typed imageArray, so as to minimize possibilities of other downstream implications.
 
 The interactive CLI options for setting the fields is included here, but not currently with exotic_gui.py support (I was concerned about window size and layout...).