### PR TITLE
Shift to 'with' for file - avoid error in finally path when bad

### DIFF
--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -565,14 +565,10 @@ def corruption_check(files):
     valid_files = []
     for file in files:
         try:
-            hdul = fits.open(name=file, memmap=False, cache=False, lazy_load_hdus=False, ignore_missing_end=True)
-            valid_files.append(file)
+            with fits.open(name=file, memmap=False, cache=False, lazy_load_hdus=False, ignore_missing_end=True) as hdui:
+                valid_files.append(file)
         except OSError as e:
             log_info(f"Warning: corrupted file found and removed from reduction\n\t-File: {file}\n\t-Reason: {e}", warn=True)
-        finally:
-            if getattr(hdul, "close", None) and callable(hdul.close):
-                hdul.close()
-            del hdul
 
     return valid_files
 


### PR DESCRIPTION
The current corruption_check has a problem, due to the hdu1 being an undefined object when an exception is thrown, which results in an exception during the finally path (getattr cannot be called on an undefined object)).

The change switches to 'best practices' for a file like object, using a 'with' to bound the open and cause the close/cleanup to be automatically completed, consisten with fits.open guidance here - https://docs.astropy.org/en/stable/io/fits/index.html