### PR TITLE
Add logging of AAVSO comparison star additions

### DIFF
--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -836,6 +836,7 @@ def check_comps(comp_stars, vsp_comp_stars, tol=10):
 
         if not inlist:
             comp_stars_list.append(vsp_comp)
+            log_info(f"Added Comparison Star #{len(comp_stars_list)} [{vsp_comp[0]},{vsp_comp[1]}] from AAVSO")
 
     return comp_stars_list, vsp_pix
 


### PR DESCRIPTION
Very simple change - just to identify that each AAVSO contributed comparison star, both to indicate that it did happen and what pixel coordinate it corresponds to.