### PR TITLE
Add plate status logging, more friendly (less redundant) errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ newfits.fits
 eaConf.json
 exotic.log.*
 pl_names.json
+/.project

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -124,6 +124,10 @@ try:  # output files
     from output_files import OutputFiles, VSPOutputFiles
 except ImportError:  # package import
     from .output_files import OutputFiles, VSPOutputFiles
+try:
+    from plate_status import PlateStatus
+except ImportError:
+    from .plate_status import PlateStatus
 try:  # plots
     from plots import plot_fov, plot_centroids, plot_obs_stats, plot_final_lightcurve, plot_flux, \
         plot_stellar_variability, plot_variable_residuals
@@ -151,7 +155,6 @@ plt.style.use(astropy_mpl_style)
 # logging -- https://docs.python.org/3/library/logging.html
 log = logging.getLogger(__name__)
 
-
 def log_info(string, warn=False, error=False):
     if error:
         print(f"\033[31m {string}\033[0m")
@@ -162,6 +165,8 @@ def log_info(string, warn=False, error=False):
     log.debug(string)
     return True
 
+# Initialze plate status log
+plateStatus = PlateStatus(log_info)
 
 def sigma_clip(ogdata, sigma=3, dt=21, po=2):
     nanmask = np.isnan(ogdata)
@@ -569,6 +574,7 @@ def nonlinear_ld(ld, filter_):
 def corruption_check(files):
     valid_files = []
     for file in files:
+        plateStatus.setCurrentFilename(file)
         try:
             with fits.open(name=file, memmap=False, cache=False, lazy_load_hdus=False, ignore_missing_end=True) as hdu1:
                 valid_files.append(file)
@@ -582,8 +588,8 @@ def corruption_check(files):
                 with fits.open(name=file, memmap=False, cache=False, lazy_load_hdus=False, ignore_missing_end=True) as hdu1:
                     valid_files.append(file)
             except OSError as e:
-                log_info(f"Warning: corrupted file found and removed from reduction\n\t-File: {file}\n\t-Reason: {e}", warn=True)
-
+                log.debug(f"Warning: corrupted file found and removed from reduction\n\t-File: {file}\n\t-Reason: {e}")
+                plateStatus.fitsFormatError(e)
     return valid_files
 
 def check_wcs(fits_file, save_directory, plate_opt, rt=False):
@@ -896,7 +902,8 @@ def transformation(image_data, file_name, roi=1):
                     except Exception:
                         pass
 
-    log_info(f"Warning: Following image failed to align - {file_name}", warn=True)
+    log.debug(f"Warning: Following image failed to align - {file_name}")
+    plateStatus.alignmentError()
     return SimilarityTransform(scale=1, rotation=0, translation=[0, 0])
 
 
@@ -1021,7 +1028,7 @@ def mesh_box(pos, box, maxx=0, maxy=0):
 
 
 # Method fits a 2D gaussian function that matches the star_psf to the star image and returns its pixel coordinates
-def fit_centroid(data, pos, psf_function=gaussian_psf, box=15, weightedcenter=True):
+def fit_centroid(data, pos, starIndex, psf_function=gaussian_psf, box=15, weightedcenter=True):
     # get sub field in image
     xv, yv = mesh_box(pos, box, maxx=data.shape[1], maxy=data.shape[0])
     subarray = data[yv, xv]
@@ -1029,7 +1036,8 @@ def fit_centroid(data, pos, psf_function=gaussian_psf, box=15, weightedcenter=Tr
         init = [np.nanmax(subarray) - np.nanmin(subarray), 1, 1, 0, np.nanmin(subarray)]
     except ValueError as ve:
         # Handle null subfield - cannot solve
-        log_info(f"Warning: empty subfield for fit_centroid at {np.round(pos, 2)}", warn=True)
+        plateStatus.outOfFrameWarning(starIndex)
+        log.debug(f"Warning: empty subfield for fit_centroid at {np.round(pos, 2)}")
         return np.empty(7) * np.nan
     # compute flux weighted centroid in x and y
     wx = np.sum(xv[0]*subarray.sum(0))/subarray.sum(0).sum()
@@ -1046,7 +1054,9 @@ def fit_centroid(data, pos, psf_function=gaussian_psf, box=15, weightedcenter=Tr
     try:
         res = least_squares(fcn2min, x0=[*pos, *init], bounds=[lo, up], jac='3-point', xtol=None, method='trf')
     except:
-        log_info(f"Warning: Measured flux amplitude is really low---are you sure there is a star at {np.round(pos, 2)}?", warn=True)
+        # Report low flux warning 
+        plateStatus.lowFluxAmplitudeWarning(starIndex, pos[0], pos[1])
+        log.debug(f"Warning: Measured flux amplitude is really low---are you sure there is a star at {np.round(pos, 2)}?")
 
         res = least_squares(fcn2min, x0=[*pos, *init], jac='3-point', xtol=None, method='lm')
 
@@ -1059,9 +1069,9 @@ def fit_centroid(data, pos, psf_function=gaussian_psf, box=15, weightedcenter=Tr
 
 
 # Method calculates the flux of the star (uses the skybg_phot method to do background sub)
-def aperPhot(data, xc, yc, r=5, dr=5):
+def aperPhot(data, starIndex, xc, yc, r=5, dr=5):
     if dr > 0 and not np.isnan(xc) and not np.isnan(yc):
-        bgflux, sigmabg, Nbg = skybg_phot(data, xc, yc, r + 2, dr)
+        bgflux, sigmabg, Nbg = skybg_phot(data, starIndex, xc, yc, r + 2, dr)
     else:
         bgflux, sigmabg, Nbg = 0, 0, 0
 
@@ -1073,7 +1083,7 @@ def aperPhot(data, xc, yc, r=5, dr=5):
     return aperture_sum, bgflux
 
 
-def skybg_phot(data, xc, yc, r=10, dr=5, ptol=99, debug=False):
+def skybg_phot(data, starIndex, xc, yc, r=10, dr=5, ptol=99, debug=False):
     # create a crude annulus to mask out bright background pixels
     xv, yv = mesh_box([xc, yc], np.round(r + dr))
     rv = ((xv - xc) ** 2 + (yv - yc) ** 2) ** 0.5
@@ -1081,8 +1091,9 @@ def skybg_phot(data, xc, yc, r=10, dr=5, ptol=99, debug=False):
     try:
         cutoff = np.nanpercentile(data[yv, xv][mask], ptol)
     except IndexError:
-        log_info(f"Warning: IndexError, problem computing sky bg for {xc:.1f}, {yc:.1f}."
-                 f"\nCheck if star is present or close to border.", warn=True)
+        plateStatus.skyBackgroundWarning(starIndex, xc, yc)
+        log.debug(f"Warning: IndexError, problem computing sky bg for {xc:.1f}, {yc:.1f}."
+                 f"\nCheck if star is present or close to border.")
 
         # create pixel wise mask on entire image
         x = np.arange(data.shape[1])
@@ -1305,11 +1316,12 @@ def save_comp_radec(wcs_file, ra_file, dec_file, comp_coords):
 def realTimeReduce(i, target_name, info_dict, ax):
     timeList, airMassList, exptimes, norm_flux = [], [], [], []
 
+    plateStatus.initializeFilenames(info_dict['images'])
     inputfiles = corruption_check(info_dict['images'])
-
     # time sort images
     times = []
     for ifile in inputfiles:
+        plateStatus.setCurrentFilename(ifile)
         extension = 0
         header = fits.getheader(filename=ifile, ext=extension)
         while header['NAXIS'] == 0:
@@ -1322,6 +1334,7 @@ def realTimeReduce(i, target_name, info_dict, ax):
     exotic_UIprevTPX = info_dict['tar_coords'][0]
     exotic_UIprevTPY = info_dict['tar_coords'][1]
 
+    plateStatus.setCurrentFilename(inputfiles[0])
     wcs_file = check_wcs(inputfiles[0], info_dict['save'], info_dict['plate_opt'], rt=True)
     comp_star = info_dict['comp_stars']
     tar_radec, comp_radec = None, []
@@ -1339,7 +1352,7 @@ def realTimeReduce(i, target_name, info_dict, ax):
         comp_radec.append((ra, dec))
 
     first_image = fits.getdata(inputfiles[0])
-    targ_sig_xy = fit_centroid(first_image, [exotic_UIprevTPX, exotic_UIprevTPY])[3:5]
+    targ_sig_xy = fit_centroid(first_image, [exotic_UIprevTPX, exotic_UIprevTPY], 0)[3:5]
 
     # aperture size in stdev (sigma) of PSF
     aper = 3 * max(targ_sig_xy)
@@ -1357,6 +1370,7 @@ def realTimeReduce(i, target_name, info_dict, ax):
 
     # open files, calibrate, align, photometry
     for i, fileName in enumerate(inputfiles):
+        plateStatus.setCurrentFilename(fileName)
         hdul = fits.open(name=fileName, memmap=False, cache=False, lazy_load_hdus=False,
                          ignore_missing_end=True)
 
@@ -1391,7 +1405,7 @@ def realTimeReduce(i, target_name, info_dict, ax):
                 pix_coords = wcs_hdr.world_to_pixel_values(tar_radec[0], tar_radec[1])
                 tx, ty = pix_coords[0].take(0), pix_coords[1].take(0)
 
-            psf_data['target'][i] = fit_centroid(imageData, [tx, ty])
+            psf_data['target'][i] = fit_centroid(imageData, [tx, ty], 0)
 
             if i != 0 and np.abs((psf_data['target'][i][2] - psf_data['target'][i - 1][2])
                                  / psf_data['target'][i - 1][2]) > 0.5:
@@ -1399,7 +1413,7 @@ def realTimeReduce(i, target_name, info_dict, ax):
 
             pix_coords = wcs_hdr.world_to_pixel_values(comp_radec[0][0], comp_radec[0][1])
             cx, cy = pix_coords[0].take(0), pix_coords[1].take(0)
-            psf_data['comp'][i] = fit_centroid(imageData, [cx, cy])
+            psf_data['comp'][i] = fit_centroid(imageData, [cx, cy], 1)
 
             if i != 0:
                 if not (tar_comp_dist['comp'][0] - 1 <= abs(int(psf_data['comp'][0][0]) - int(psf_data['target'][i][0])) <= tar_comp_dist['comp'][0] + 1 and
@@ -1416,10 +1430,10 @@ def realTimeReduce(i, target_name, info_dict, ax):
                 tform = transformation(np.array([imageData, firstImage]), fileName)
 
             tx, ty = tform([exotic_UIprevTPX, exotic_UIprevTPY])[0]
-            psf_data['target'][i] = fit_centroid(imageData, [tx, ty])
+            psf_data['target'][i] = fit_centroid(imageData, [tx, ty], 0)
 
             cx, cy = tform(comp_star)[0]
-            psf_data['comp'][i] = fit_centroid(imageData, [cx, cy])
+            psf_data['comp'][i] = fit_centroid(imageData, [cx, cy], 1)
 
             if i == 0:
                 tar_comp_dist['comp'][0] = abs(int(psf_data['comp'][0][0]) - int(psf_data['target'][0][0]))
@@ -1431,14 +1445,15 @@ def realTimeReduce(i, target_name, info_dict, ax):
             aper *= sigma
             annulus *= sigma
 
-        tFlux = aperPhot(imageData, psf_data['target'][i, 0], psf_data['target'][i, 1], aper, annulus)[0]
-        cFlux = aperPhot(imageData, psf_data['comp'][i, 0], psf_data['comp'][i, 1], aper, annulus)[0]
+        tFlux = aperPhot(imageData, 0, psf_data['target'][i, 0], psf_data['target'][i, 1], aper, annulus)[0]
+        cFlux = aperPhot(imageData, 1, psf_data['comp'][i, 0], psf_data['comp'][i, 1], aper, annulus)[0]
         norm_flux.append(tFlux / cFlux)
 
         # close file + delete from memory
         hdul.close()
         del hdul
-    del imageData
+        # Replaced each loop, so clean up
+        del imageData
 
     ax.clear()
     ax.set_title(target_name)
@@ -1806,12 +1821,13 @@ def main():
 
             airMassList, exptimes = [], []
 
+            plateStatus.initializeFilenames(exotic_infoDict['images'])
             inputfiles = corruption_check(exotic_infoDict['images'])
-
             # time sort images
             times, jd_times = [], []
             for file in inputfiles:
                 extension = 0
+                plateStatus.setCurrentFilename(file)
                 header = fits.getheader(filename=file, ext=extension)
                 while header['NAXIS'] == 0:
                     extension += 1
@@ -1820,6 +1836,7 @@ def main():
                 jd_times.append(img_time(header, var=True))
 
             extension = 0
+            plateStatus.setCurrentFilename(inputfiles[0])
             header = fits.getheader(filename=inputfiles[0], ext=extension)
             while header['NAXIS'] == 0:
                 extension += 1
@@ -1840,17 +1857,18 @@ def main():
             si = np.argsort(times)
             times = np.array(times)[si]
             jd_times = np.array(jd_times)[si]
-
             inputfiles = np.array(inputfiles)[si]
+            
             exotic_UIprevTPX = exotic_infoDict['tar_coords'][0]
             exotic_UIprevTPY = exotic_infoDict['tar_coords'][1]
 
             # fit target in the first image and use it to determine aperture and annulus range
             inc = 0
             for ifile in inputfiles:
+                plateStatus.setCurrentFilename(ifile)
                 first_image = fits.getdata(ifile)
                 try:
-                    get_first = fit_centroid(first_image, [exotic_UIprevTPX, exotic_UIprevTPY])
+                    get_first = fit_centroid(first_image, [exotic_UIprevTPX, exotic_UIprevTPY], 0)
                     if np.isnan(get_first[0]):
                         inc += 1
                     else:
@@ -1865,10 +1883,12 @@ def main():
                 inputfiles = inputfiles[inc:]
                 times = times[inc:]
                 jd_times = jd_times[inc:]
+            plateStatus.setCurrentFilename(inputfiles[0])
 
             wcs_file = check_wcs(inputfiles[0], exotic_infoDict['save'], exotic_infoDict['plate_opt'])
             img_scale_str, img_scale = get_img_scale(header, wcs_file, exotic_infoDict['pixel_scale'])
             compStarList = exotic_infoDict['comp_stars']
+            plateStatus.initializeComparisonStarCount(len(compStarList))
             tar_radec, comp_radec = None, []
             vsp_list = []
             chart_id, vsp_comp_stars = None, None
@@ -1904,6 +1924,7 @@ def main():
                     exotic_infoDict['comp_stars'], vsp_list = check_comps(exotic_infoDict['comp_stars'], vsp_comp_stars)
 
                 compStarList = exotic_infoDict['comp_stars']
+                plateStatus.initializeComparisonStarCount(len(compStarList))
 
             # aperture sizes in stdev (sigma) of PSF
             apers = np.linspace(1.5, 6, 20)
@@ -1932,6 +1953,7 @@ def main():
 
             # open files, calibrate, align, photometry
             for i, fileName in enumerate(inputfiles):
+                plateStatus.setCurrentFilename(fileName)
                 hdul = fits.open(name=fileName, memmap=False, cache=False, lazy_load_hdus=False,
                                  ignore_missing_end=True)
 
@@ -1970,7 +1992,7 @@ def main():
                         pix_coords = wcs_hdr.world_to_pixel_values(tar_radec[0], tar_radec[1])
                         tx, ty = pix_coords[0].take(0), pix_coords[1].take(0)
 
-                    psf_data['target'][i] = fit_centroid(imageData, [tx, ty])
+                    psf_data['target'][i] = fit_centroid(imageData, [tx, ty], 0)
 
                     # TODO: Add check for flux on target/comp stars relative to others in the field
                     # in case of cloudy data, large changes, etc.
@@ -1983,10 +2005,7 @@ def main():
 
                         pix_coords = wcs_hdr.world_to_pixel_values(comp_radec[j][0], comp_radec[j][1])
                         cx, cy = pix_coords[0].take(0), pix_coords[1].take(0)
-                        if cx > 0 and cy > 0:
-                            psf_data[ckey][i] = fit_centroid(imageData, [cx, cy])
-                        else:
-                            psf_data[ckey][i] = np.empty(7) * np.nan
+                        psf_data[ckey][i] = fit_centroid(imageData, [cx, cy], j+1)
 
                         if i != 0:
                             if not (tar_comp_dist[ckey][0] - 1 <= abs(int(psf_data[ckey][i][0]) - int(psf_data['target'][i][0])) <= tar_comp_dist[ckey][0] + 1 and
@@ -2003,16 +2022,13 @@ def main():
                         tform = transformation(np.array([imageData, firstImage]), fileName)
 
                     tx, ty = tform([exotic_UIprevTPX, exotic_UIprevTPY])[0]
-                    psf_data['target'][i] = fit_centroid(imageData, [tx, ty])
+                    psf_data['target'][i] = fit_centroid(imageData, [tx, ty], 0)
 
                     for j, coord in enumerate(compStarList):
                         ckey = f"comp{j + 1}"
 
                         cx, cy = tform(coord)[0]
-                        if cx > 0 and cy > 0:
-                            psf_data[ckey][i] = fit_centroid(imageData, [cx, cy])
-                        else:
-                            psf_data[ckey][i] = np.empty(7) * np.nan
+                        psf_data[ckey][i] = fit_centroid(imageData, [cx, cy], j+1)
 
                         if i == 0:
                             tar_comp_dist[ckey][0] = abs(int(psf_data[ckey][0][0]) - int(psf_data['target'][0][0]))
@@ -2027,7 +2043,7 @@ def main():
                 for a, aper in enumerate(apers):
                     for an, annulus in enumerate(annuli):
                         if not np.isnan(psf_data['target'][i, 0]):
-                            aper_data["target"][i][a][an], aper_data["target_bg"][i][a][an] = aperPhot(imageData,
+                            aper_data["target"][i][a][an], aper_data["target_bg"][i][a][an] = aperPhot(imageData, 0,
                                                                                                         psf_data['target'][i, 0],
                                                                                                         psf_data['target'][i, 1],
                                                                                                         aper, annulus)
@@ -2039,7 +2055,7 @@ def main():
                             ckey = f"comp{j + 1}"
                             if not np.isnan(psf_data[ckey][i][0]):
                                 aper_data[ckey][i][a][an], \
-                                aper_data[f"{ckey}_bg"][i][a][an] = aperPhot(imageData, psf_data[ckey][i, 0],
+                                aper_data[f"{ckey}_bg"][i][a][an] = aperPhot(imageData, j + 1, psf_data[ckey][i, 0],
                                                                             psf_data[ckey][i, 1], aper, annulus)
                             else:
                                 aper_data[ckey][i][a][an] = np.nan
@@ -2048,7 +2064,7 @@ def main():
                 # close file + delete from memory
                 hdul.close()
                 del hdul
-            del imageData
+                del imageData
 
             # filter bad images
             badmask = np.isnan(psf_data["target"][:, 0]) | (psf_data["target"][:, 0] == 0) | (aper_data["target"][:, 0, 0] == 0) | np.isnan(
@@ -2522,6 +2538,10 @@ def main():
                 VSPoutput_files.aavso(goodAirmasses)
         except Exception as e:
             log_info(f"\nError: Could not create vspAAVSO.txt. {error_txt}\n\t{e}", error=True)
+        try:
+            output_files.plate_status(plateStatus)
+        except Exception as e:
+            log_info(f"\nError: Could not create plate_status.csv. {error_txt}\n\t{e}", error=True)
 
         log_info("Output Files Saved")
 

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -1327,7 +1327,9 @@ def realTimeReduce(i, target_name, info_dict, ax):
         while header['NAXIS'] == 0:
             extension += 1
             header = fits.getheader(filename=ifile, ext=extension)
-        times.append(img_time(header))
+        obsTime = img_time(header)
+        times.append(obsTime)
+        plateStatus.setObsTime(obsTime)
 
     si = np.argsort(times)
     inputfiles = np.array(inputfiles)[si]
@@ -1832,7 +1834,9 @@ def main():
                 while header['NAXIS'] == 0:
                     extension += 1
                     header = fits.getheader(filename=file, ext=extension)
-                times.append(img_time(header))
+                obsTime = img_time(header)
+                times.append(obsTime)
+                plateStatus.setObsTime(obsTime)
                 jd_times.append(img_time(header, var=True))
 
             extension = 0

--- a/exotic/output_files.py
+++ b/exotic/output_files.py
@@ -10,6 +10,10 @@ try:
     from version import __version__
 except ImportError:
     from .version import __version__
+try:
+    from plate_status import PlateStatus
+except ImportError:
+    from .plate_status import PlateStatus
 
 
 class OutputFiles:
@@ -130,7 +134,9 @@ class OutputFiles:
                 f.write(f"{round(self.fit.time[aavsoC], 8)},{round(self.fit.data[aavsoC], 7)},"
                         f"{round(self.fit.dataerr[aavsoC], 7)},{round(airmasses[aavsoC], 7)},"
                         f"{round(self.fit.airmass_model[aavsoC], 7)}\n")
-
+    def plate_status(self, plate_status: PlateStatus):
+        plate_status_file = self.dir / "temp" / f"PlateStatus_{self.p_dict['pName']}_{self.i_dict['date']}.csv"
+        plate_status.writePlateStatus(plate_status_file)
 
 class VSPOutputFiles:
     def __init__(self, fit, p_dict, i_dict, vsp_params):

--- a/exotic/plate_status.py
+++ b/exotic/plate_status.py
@@ -1,0 +1,91 @@
+
+class PlateStatus:
+    def __init__(self, logfunc):
+        self.statusByFilename = dict()
+        self.filenameByIndex = []
+        self.filename = "N/A"
+        self.errorcodes = set()
+        self.logfunc = logfunc
+        self.errorcodes.add("outofframe_target")
+        self.errorcodes.add("lowflux_target")
+        self.errorcodes.add("skybg_target")
+        self.errorcodes.add("fits_error")
+        self.errorcodes.add("alignment_error")
+    # Initialze set of files, as well as ordered index
+    def initializeFilenames(self, filenames: list[str]):
+        self.filenameByIndex = filenames.copy()
+        for fneme in filenames:
+            if fneme not in self.statusByFilename:
+                self.statusByFilename[fneme] = {}
+        return self
+    # Initialize comparison star count
+    def initializeComparisonStarCount(self, compCount: int):
+        for i in range(compCount):
+            self.errorcodes.add(f"outofframe_comp{i+1}")
+            self.errorcodes.add(f"lowflux_comp{i+1}")
+            self.errorcodes.add(f"skybg_comp{i+1}")            
+    # Sets current filename (for any reported errors) - sets starIndex=0 (target)
+    def setCurrentFilename(self, filename: str):
+        if filename not in self.statusByFilename:
+            self.statusByFilename[filename] = {}
+        self.filename = filename
+        return self
+    # Log an error
+    def _logError(self, errorcode: str, message: str) -> None:
+        if self.filename not in self.statusByFilename:
+            self.statusByFilename[self.filename] = {}
+        rec = self.statusByFilename[self.filename]
+        if errorcode in rec:
+            return
+        # Mark error on this file
+        rec[errorcode] = True
+        self.errorcodes.add(errorcode)
+        # And log new warning
+        self.logfunc(message, warn=True)
+    # Report out of frame warning for start ;index' (0=target, 1+=comp #N)
+    def outOfFrameWarning(self, starIndex):
+        if starIndex == 0:  # Target star
+            self._logError("outofframe_target",
+                f"Target star beyond edge of file {self.filename}")
+        else:
+            self._logError(f"outofframe_comp{starIndex}",
+                f"Comparison star #{starIndex} star beyond edge of file {self.filename}")
+    # Report low flux amplitude warning for start ;index' (0=target, 1+=comp #N)
+    def lowFluxAmplitudeWarning(self, starIndex: int, xc: float, yc: float):
+        if starIndex == 0:  # Target star
+            self._logError("lowflux_target",
+                f"Measured flux for Target star is low in file  {self.filename} - are you sure there is a star at [{xc:.1f}, {yc:.1f}]?")
+        else:
+            self._logError(f"lowflux_comp{starIndex}",
+                f"Measured flux for Comparison star #{starIndex} is low in file {self.filename} - are you sure there is a star at [{xc:.1f}, {yc:.1f}]?")
+    # Report sky background warning for start ;index' (0=target, 1+=comp #N)
+    def skyBackgroundWarning(self, starIndex: int, xc: float, yc: float):
+        if starIndex == 0:  # Target star
+            self._logError("skybg_target",
+                f"Sky background error for Target star for file {self.filename} - are you sure there is a star at [{xc:.1f}, {yc:.1f}]?")
+        else:
+            self._logError(f"skybg_comp{starIndex}",
+                f"Sky background error for Comparison star #{starIndex} for file {self.filename} - are you sure there is a star at [{xc:.1f}, {yc:.1f}]?")
+    # Reort file format error
+    def fitsFormatError(self, e: OSError):
+        self._logError("fits_error",
+            f"Corrupted file {self.filename} ({e}) --removed from reduction")
+    # Reort alignment error
+    def alignmentError(self):
+        self._logError("alignment_error",
+            f"File {self.filename} failed to align with first file")
+    # Write plate status to CSV file
+    def writePlateStatus(self, file: str):
+        with open(file, 'w') as f:
+            cols = list(self.errorcodes)
+            cols.sort()
+            f.write(f"# filename,{','.join(cols)}\n")
+            for file in self.filenameByIndex:
+                rec = self.statusByFilename[file]
+                line = '"' + file + '"';
+                for col in cols:
+                    if col in rec:
+                        line = f"{line},{rec[col]}"
+                    else:
+                        line = f"{line},False"
+                f.write(f"{line}\n")

--- a/exotic/plate_status.py
+++ b/exotic/plate_status.py
@@ -27,6 +27,7 @@ class PlateStatus:
             self.errorcodes.add(f"skybg_comp{i+1}")            
     # Sets current filename (for any reported errors) - sets starIndex=0 (target)
     def setCurrentFilename(self, filename: str):
+        filename = str(filename)
         if filename not in self.statusByFilename:
             self.statusByFilename[filename] = {}
         self.filename = filename


### PR DESCRIPTION
This is intended to both act as a usability improvement (making the errors presented to the users for various frame related problems more oriented around what they need to know, versus a more programmer-centric error), and an improvement in the final processing artifacts for the run (specifically, the creation of a PlateStatus-<target>-<date>.csv file recording the various error/warning conditions for each science frame provided by the user - including those rejected due to FITS formatting, inability to be aligned versus the first plate, low flux, and out of frame conditions for the target and each comparison star).
Specifically, existing log messages were switched to log.debug (so they are there for programmer debug, but don't show in the user's console), while more friendly warning message are show (and deduplicated on each frame - having an out of frame error for every aperture size attempted on a given frame is excessive).  The status for all input files are ultimately recorded, and used to generate a final CSV file in the 'temp' directory, recording all the relevant frame-specific issues that may or may not have caused the frame to either be rejected or possibly not be fully utilized.