### PR TITLE
Handle times, jd_times arrays properly when first image files skipped

### DIFF
--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -1853,6 +1853,7 @@ def main():
                     del first_image
 
             if inc > 0:
+                log_info(f"Skipping first {inc} files - Target star not found")
                 inputfiles = inputfiles[inc:]
                 times = times[inc:]
                 jd_times = jd_times[inc:]

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -1852,7 +1852,11 @@ def main():
                 finally:
                     del first_image
 
-            inputfiles = inputfiles[inc:]
+            if inc > 0:
+                inputfiles = inputfiles[inc:]
+                times = times[inc:]
+                jd_times = jd_times[inc:]
+
             wcs_file = check_wcs(inputfiles[0], exotic_infoDict['save'], exotic_infoDict['plate_opt'])
             img_scale_str, img_scale = get_img_scale(header, wcs_file, exotic_infoDict['pixel_scale'])
             compStarList = exotic_infoDict['comp_stars']


### PR DESCRIPTION
This is a simple fix for what is probably a rare scenario, but it should avoid a serious problem when it does occur: when the fix_centroid check on the first frames throws an error or otherwise does not match, and the bad frames are skipped, the pruning of the inputfiles array is done, but the already existing times and jd_times array does not have the corresponding pruning done - this would cause an off by N problem for all downstream processing, as well as the arrays not being of matching lengths during model processing and the like.
I've also added a log message for when this pruning does occur