### PR TITLE
Handle tFlux, cFlux sigma clipping during model matches

### DIFF
--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -2106,10 +2106,10 @@ def main():
                     # goodNormUnc = np.copy(myfit.dataerr)
                     nonBJDTimes = np.copy(myfit.time)
                     goodAirmasses = np.copy(myfit.airmass)
-                    goodTargets = tFlux
-                    goodReferences = cFlux
-                    goodTUnc = tFlux ** 0.5
-                    goodRUnc = cFlux ** 0.5
+                    goodTargets = tFlux1
+                    goodReferences = cFlux1
+                    goodTUnc = tFlux1 ** 0.5
+                    goodRUnc = cFlux1 ** 0.5
                     bestlmfit = myfit
 
                     finXTargCent = psf_data["target"][:, 0]
@@ -2158,10 +2158,10 @@ def main():
                         nonBJDTimes = np.copy(myfit.time)
                         # nonBJDPhases = np.copy(myfit.phase)
                         goodAirmasses = np.copy(myfit.airmass)
-                        goodTargets = tFlux
-                        goodReferences = cFlux
-                        goodTUnc = tFlux ** 0.5
-                        goodRUnc = cFlux ** 0.5
+                        goodTargets = tFlux1
+                        goodReferences = cFlux1
+                        goodTUnc = tFlux1 ** 0.5
+                        goodRUnc = cFlux1 ** 0.5
                         # goodResids = myfit.residuals
                         bestlmfit = myfit
 
@@ -2209,10 +2209,10 @@ def main():
                             nonBJDTimes = np.copy(myfit.time)
                             # nonBJDPhases = np.copy(myfit.phase)
                             goodAirmasses = np.copy(myfit.airmass)
-                            goodTargets = tFlux[aper_mask]
-                            goodReferences = cFlux
-                            goodTUnc = tFlux[aper_mask] ** 0.5
-                            goodRUnc = cFlux ** 0.5
+                            goodTargets = tFlux1
+                            goodReferences = cFlux1
+                            goodTUnc = tFlux1 ** 0.5
+                            goodRUnc = cFlux1 ** 0.5
                             # goodResids = myfit.residuals
                             bestlmfit = myfit
 

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -1475,6 +1475,7 @@ def fit_lightcurve(times, tFlux, cFlux, airmass, ld, pDict):
 
     if np.sum(~nanmask) <= 1:
         log_info('No data left after filtering', warn=True)
+        return None, None, None
     else:
         arrayFinalFlux = arrayFinalFlux[~nanmask]
         arrayNormUnc = arrayNormUnc[~nanmask]
@@ -2085,15 +2086,16 @@ def main():
                 cFlux = 2 * np.pi * psf_data[ckey][:, 2] * psf_data[ckey][:, 3] * psf_data[ckey][:, 4]
                 myfit, tFlux1, cFlux1 = fit_lightcurve(times, tFlux, cFlux, airmass, ld, pDict)
 
-                for k in myfit.bounds.keys():
-                    log.debug(f"  {k}: {myfit.parameters[k]:.6f}")
+                if myfit is not None:
+                    for k in myfit.bounds.keys():
+                        log.debug(f"  {k}: {myfit.parameters[k]:.6f}")
 
-                log.debug("The Residual Standard Deviation is: "
-                          f"{round(100 * myfit.residuals.std() / np.median(myfit.data), 6)}%")
-                log.debug(f"The Mean Squared Error is: {round(np.sum(myfit.residuals ** 2), 6)}\n")
+                    log.debug("The Residual Standard Deviation is: "
+                            f"{round(100 * myfit.residuals.std() / np.median(myfit.data), 6)}%")
+                    log.debug(f"The Mean Squared Error is: {round(np.sum(myfit.residuals ** 2), 6)}\n")
 
-                resstd = myfit.residuals.std() / np.median(myfit.data)
-                if minSTD > resstd:  # If the standard deviation is less than the previous min
+                    resstd = myfit.residuals.std() / np.median(myfit.data)
+                if minSTD > resstd and myfit is not None:  # If the standard deviation is less than the previous min
                     bestCompStar = j + 1
                     comp_coords = compStarList[j]
                     minSTD = resstd
@@ -2137,15 +2139,16 @@ def main():
                     # fit without a comparison star
                     myfit, tFlux1, cFlux1 = fit_lightcurve(times, tFlux, np.ones(tFlux.shape[0]), airmass, ld, pDict)
 
-                    for k in myfit.bounds.keys():
-                        log.debug(f"  {k}: {myfit.parameters[k]:.6f}")
+                    if myfit is not None:
+                        for k in myfit.bounds.keys():
+                            log.debug(f"  {k}: {myfit.parameters[k]:.6f}")
 
-                    log.debug("The Residual Standard Deviation is: "
-                              f"{round(100 * myfit.residuals.std() / np.median(myfit.data), 6)}%")
-                    log.debug(f"The Mean Squared Error is: {round(np.sum(myfit.residuals ** 2), 6)}\n")
+                        log.debug("The Residual Standard Deviation is: "
+                                f"{round(100 * myfit.residuals.std() / np.median(myfit.data), 6)}%")
+                        log.debug(f"The Mean Squared Error is: {round(np.sum(myfit.residuals ** 2), 6)}\n")
 
-                    resstd = myfit.residuals.std() / np.median(myfit.data)
-                    if minSTD > resstd:  # If the standard deviation is less than the previous min
+                        resstd = myfit.residuals.std() / np.median(myfit.data)
+                    if minSTD > resstd and myfit is not None:  # If the standard deviation is less than the previous min
                         minSTD = resstd
                         minAperture = -aper
                         minAnnulus = annulus
@@ -2178,23 +2181,24 @@ def main():
 
                         myfit, tFlux1, cFlux1 = fit_lightcurve(times[aper_mask], tFlux[aper_mask], cFlux, airmass[aper_mask], ld, pDict)
 
-                        if j in vsp_num:
-                            temp_ref_flux[j] = {
-                                'myfit': myfit,
-                                'tflux': tFlux1,
-                                'cflux': cFlux1,
-                                'xy': compStarList[j]
-                            }
+                        if myfit is not None:
+                            if j in vsp_num:
+                                temp_ref_flux[j] = {
+                                    'myfit': myfit,
+                                    'tflux': tFlux1,
+                                    'cflux': cFlux1,
+                                    'xy': compStarList[j]
+                                }
 
-                        for k in myfit.bounds.keys():
-                            log.debug(f"  {k}: {myfit.parameters[k]:.6f}")
+                            for k in myfit.bounds.keys():
+                                log.debug(f"  {k}: {myfit.parameters[k]:.6f}")
 
-                        log.debug("The Residual Standard Deviation is: "
-                                  f"{round(100 * myfit.residuals.std() / np.median(myfit.data), 6)}%")
-                        log.debug(f"The Mean Squared Error is: {round(np.sum(myfit.residuals ** 2), 6)}\n")
+                            log.debug("The Residual Standard Deviation is: "
+                                    f"{round(100 * myfit.residuals.std() / np.median(myfit.data), 6)}%")
+                            log.debug(f"The Mean Squared Error is: {round(np.sum(myfit.residuals ** 2), 6)}\n")
 
-                        resstd = myfit.residuals.std() / np.median(myfit.data)
-                        if minSTD > resstd:  # If the standard deviation is less than the previous min
+                            resstd = myfit.residuals.std() / np.median(myfit.data)
+                        if minSTD > resstd and myfit is not None:  # If the standard deviation is less than the previous min
                             bestCompStar = j + 1
                             comp_coords = compStarList[j]
                             minSTD = resstd


### PR DESCRIPTION
I believe this is behind some of the errors we've seen, relative to funky plots (with multiple lines) as well as exceptions on plot_flux calls (due to inconsistent array sizes/layouts).

Specifically, this is driven by fit_lightcurve, which can prune the provided times and flux values based on sigma clipping:

https://github.com/rzellem/EXOTIC/blob/develop/exotic/exotic.py#L1449

When this happens, the times and flux arrays used for the light curve can be reduced below the input population - these reduced versions are returned in myfit and as cFlux1 and tFlux1, respectively. When no points are sigma clipped, these are the same as those input to the call (which is why things work most of the time).

The use of the UNPRUNED values later (such as https://github.com/rzellem/EXOTIC/blob/develop/exotic/exotic.py#L2148):

                    goodTargets = tFlux
                    goodReferences = cFlux
                    goodTUnc = tFlux ** 0.5
                    goodRUnc = cFlux ** 0.5
works when no pruning has occurred, but breaks the assumption of length and index value consistency leveraged later (specifically, around further reordering and pruning via [si][gi] - generated here (https://github.com/rzellem/EXOTIC/blob/develop/exotic/exotic.py#L2271). The use of these for plot_flux (https://github.com/rzellem/EXOTIC/blob/develop/exotic/exotic.py#L2322) will then result in index and length inconsistencies between times and the flux arrays.

The need for this is also supported by the existing use of cFlux1/tFlux1, which demonstrate the resulting index/length correlation.