### PR TITLE
Prevent exception in sigma clip when data includes NaNs

### DIFF
--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -173,7 +173,7 @@ plateStatus = PlateStatus(log_info)
 def sigma_clip(ogdata, sigma=3, dt=21, po=2):
     nanmask = np.isnan(ogdata)
 
-    if po < dt <= len(ogdata):
+    if po < dt <= len(ogdata[~nanmask]):
         mdata = savgol_filter(ogdata[~nanmask], window_length=dt, polyorder=po)
         # mdata = median_filter(ogdata[~nanmask], dt)
         res = ogdata[~nanmask] - mdata


### PR DESCRIPTION
the sigma_clip function can result in an exception when applying the savgol_filter when the data being processed includes NaNs (as it can when comparison stars drift out of field or are obstructed.
The existing code tests to avoid using the savgol_filter inappropriately (when the array of data is too small), but the test fails to account for the fact that the NaNs are stripped from the array before being used: specifically, it checks for len(ogdata) being greater that or equal to the window_length to be used, but then uses ogdata[~nanmask] as the data to be processed - since [~nanmask] will shrink the array length if any of the fields were NaNs, this makes the previous len(ogdata) test inadequate.  This change simply adjusts the constraint test to be consistent with the data as passed to the savpol_filter function.