### PR TITLE
Add support for fpack based extensions

### DIFF
--- a/exotic/inputs.py
+++ b/exotic/inputs.py
@@ -201,7 +201,7 @@ class Inputs:
 
 
 def check_imaging_files(directory, img_type):
-    file_extensions = ['.fits', '.fit', '.fts', '.fz', '.fits.gz', '.fit.gz']
+    file_extensions = ['.fits', '.fit', '.fts', '.fz', '.fits.gz', '.fit.gz', '.fits.fz', 'fit.fz']
     input_files = []
 
     while True:


### PR DESCRIPTION
astropy already supports, so just need to recognize appropriate extensions (.fits.fz, fit.fz).   Used fpack to compress files (wow, it works well!), and confirmed correct behavior.