### PR TITLE
Changes to colab.py and plotting.py to fix bokeh related errors in Colab

### DIFF
--- a/exotic/api/colab.py
+++ b/exotic/api/colab.py
@@ -109,7 +109,7 @@ def display_image(filename):
     # )
 
     # create a figure with text on mouse hover
-    fig = figure(tooltips=[("x", "$x"), ("y", "$y"), ("value", "@image")], plot_width=p_width, plot_height=p_height,
+    fig = figure(tooltips=[("x", "$x"), ("y", "$y"), ("value", "@image")], width=p_width, height=p_height,
         tools=[PanTool(),BoxZoomTool(),WheelZoomTool(),ResetTool(),HoverTool()])
     fig.x_range.range_padding = fig.y_range.range_padding = 0
 

--- a/exotic/api/plotting.py
+++ b/exotic/api/plotting.py
@@ -118,7 +118,7 @@ def plot_image(filename, save=False, bg_min=60, bg_max=99):
 
     # create a figure with text on mouse hover\
     print("Saturated pixels are marked with red. These are pixels which have exceeded the maximum value for brightness, and are thus not suitable for use as comparison stars.")
-    fig = figure(tooltips=[("x", "$x"), ("y", "$y"), ("value", "@image")], plot_width=800, plot_height=800,
+    fig = figure(tooltips=[("x", "$x"), ("y", "$y"), ("value", "@image")], width=800, height=800,
         tools=[PanTool(),BoxZoomTool(),WheelZoomTool(),ResetTool(),HoverTool()])
     fig.x_range.range_padding = fig.y_range.range_padding = 0
 


### PR DESCRIPTION
In exotic/api/colab.py
    fig = figure(tooltips=[("x", "$x"), ("y", "$y"), ("value", "@image")], plot_width=p_width, plot_height=p_height,
->
    fig = figure(tooltips=[("x", "$x"), ("y", "$y"), ("value", "@image")], width=p_width, height=p_height,
In exotic/api/plotting.py
    fig = figure(tooltips=[("x", "$x"), ("y", "$y"), ("value", "@image")], plot_width=800, plot_height=800,
->
    fig = figure(tooltips=[("x", "$x"), ("y", "$y"), ("value", "@image")], width=800, height=800,