### PR TITLE
Update Trusted Publishing spec to meet requirements

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,14 +29,20 @@ jobs:
       run: |
         python3 -m build --wheel
         python3 setup.py sdist --format=zip
+    - name: Verify package
+      run: |
+        twine check dist/*
     - name: Store package
       uses: actions/upload-artifact@v4
       with:
         name: python-package-distribution
-        path: dist/
+        path:
+          dist/*.whl
+          dist/*.zip
 
   release:
     runs-on: ubuntu-latest
+    needs: build
     environment:
       name: release
     permissions:
@@ -50,4 +56,4 @@ jobs:
     - name: Publish package (PyPi)
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        repository-url: https://pypi.org/p/exotic  # for testing sub https://test.pypi.org/legacy/
+        repository-url: https://pypi.org/p/exotic/  # for testing sub https://test.pypi.org/legacy/


### PR DESCRIPTION
- Limit files to proper wheel and archive.
- Specify job dependencies
- Fix missing slash in publication directory 