### PR TITLE
Update Trusted Publishing spec to fix bugs

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -57,7 +57,5 @@ jobs:
     - name: Publish package (PyPi)
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        attestations: true
         print-hash: true
         repository-url: https://pypi.org/p/exotic/  # for testing sub https://test.pypi.org/legacy/
-


### PR DESCRIPTION
- Remove experimental support for PEP 740 attestations