### PR TITLE
Issue 1313: Use urllib.parse.quote for URL-encoding the ADQL query (Part 1)

### DIFF
--- a/exotic/api/nea.py
+++ b/exotic/api/nea.py
@@ -130,10 +130,7 @@ class NASAExoplanetArchive:
 
     def _tap_query(self, base_url, query, dataframe=True):
         # Build the ADQL query string
-        adql_query = ''
-        for k in query:
-            if k != "format":
-                adql_query += f"{k} {query[k]} "
+        adql_query = ' '.join(f"{k} {v}" for k, v in query.items() if k != "format")
         adql_query = adql_query.strip()  # Remove any trailing space
 
         # URL-encode the entire ADQL query


### PR DESCRIPTION
The existing `_tap_query` method constructs the query URL by manually replacing spaces with plus signs` uri_full = uri_full.replace(' ', '+')` but does not URL-encode the entire query string. 

This means that when querying exoplanets with a plus sign (+) in their names, such as "WD 1856+534 b", the planet will not be found.

We can use `urllib.parse` for URL-encoding the ADQL query.