### PR TITLE
Update Trusted Publishing spec to fix bugs

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -58,4 +58,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         print-hash: true
-        repository-url: https://pypi.org/p/exotic/  # for testing sub https://test.pypi.org/legacy/
+        repository-url: https://upload.pypi.org/legacy/  # for testing sub https://test.pypi.org/legacy/


### PR DESCRIPTION
- Update release endpoint URL as recommended by release bot
