### PR TITLE
Normalize branches ahead of 4.2.0 release

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -57,7 +57,5 @@ jobs:
     - name: Publish package (PyPi)
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        attestations: true
         print-hash: true
         repository-url: https://pypi.org/p/exotic/  # for testing sub https://test.pypi.org/legacy/
-

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -58,4 +58,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         print-hash: true
-        repository-url: https://pypi.org/p/exotic/  # for testing sub https://test.pypi.org/legacy/
+        repository-url: https://upload.pypi.org/legacy/  # for testing sub https://test.pypi.org/legacy/


### PR DESCRIPTION
- Merge trusted publishing changes to `develop` branch for inclusion with next release