### PR TITLE
Issue 1125: Include AAVSO comparison stars as default during initialization file construction for Colab

### DIFF
--- a/exotic/api/colab.py
+++ b/exotic/api/colab.py
@@ -370,10 +370,13 @@ def make_inits_file(planetary_params, image_dir, output_dir, first_image, targ_c
             "Observing Notes": "%s",
 
             "Plate Solution? (y/n)": "y",
-            "Align Images? (y/n)": "y",
+            "Add Comparison Stars from AAVSO? (y/n)": "y",
 
             "Target Star X & Y Pixel": %s,
-            "Comparison Star(s) X & Y Pixel": %s
+            "Comparison Star(s) X & Y Pixel": %s,
+            
+            "Demosaic Format": null,
+            "Demosaic Output": null
     },    
     "optional_info": {
             "Pixel Scale (Ex: 5.21 arcsecs/pixel)": null,


### PR DESCRIPTION
I was testing out the colab notebooks earlier and saw that it was prompting AAVSO comp stars from the command line. I also noticed it was an issue asking for the comparison stars to be default per issue #1125. I updated the construct of the file to conform to today's initialization file.

**Please do not release this in v4.2.** Save for 4.3 (next week).

Closes #1125