### PR TITLE
Fix mesh_box extending beyond the border of the frame; Re-enable AAVSO comparison stars to Y in Colab

### DIFF
--- a/exotic/api/colab.py
+++ b/exotic/api/colab.py
@@ -370,7 +370,7 @@ def make_inits_file(planetary_params, image_dir, output_dir, first_image, targ_c
             "Observing Notes": "%s",
 
             "Plate Solution? (y/n)": "y",
-            "Add Comparison Stars from AAVSO? (y/n)": "n",
+            "Add Comparison Stars from AAVSO? (y/n)": "y",
 
             "Target Star X & Y Pixel": %s,
             "Comparison Star(s) X & Y Pixel": %s,

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -1272,7 +1272,9 @@ def aperPhot(data, starIndex, xc, yc, r=5, dr=5):
 
 def skybg_phot(data, starIndex, xc, yc, r=10, dr=5, ptol=99, debug=False):
     # create a crude annulus to mask out bright background pixels
-    xv, yv = mesh_box([xc, yc], np.round(r + dr))
+    # the box will not extend beyond the borders of the image
+    image_height, image_width = data.shape
+    xv, yv = mesh_box([xc, yc], np.round(r + dr), maxx=image_width, maxy=image_height)
     rv = ((xv - xc) ** 2 + (yv - yc) ** 2) ** 0.5
     mask = (rv > r) & (rv < (r + dr))
     try:


### PR DESCRIPTION
This PR fix #1336 by constraining the mesh_box within the borders of the image.

In particular this was affecting some datasets where AAVSO comparison stars were relatively near the border, causing the process to be slow and errors like the following: 
`Sky background error for Comparison star #4 for file C:\Users\ivenz\Downloads\exotic_sample_data_error_2024-10-21\2024-10-21\LIGHT\HD 209458_2062.FIT - are you sure there is a star at [915.6, 582.0]?`

Very important, this PR also re-enable AAVSO comparison stars by default in Colab. It was disabled a month ago mainly because of issue #1336

@tamimfatahi @rzellem 