### PR TITLE
Fix issue 1364: AID format changes due to new AAVSO upload tool

### DIFF
--- a/exotic/output_files.py
+++ b/exotic/output_files.py
@@ -168,9 +168,9 @@ class AIDOutputFiles:
 
             f.write("#NAME,DATE,MAG,MERR,FILT,TRANS,MTYPE,CNAME,CMAG,KNAME,KMAG,AMASS,GROUP,CHART,NOTES\n")
             for vsp_p in self.vsp_params:
-                f.write(f"{self.auid},{round(vsp_p['time'], 5)},{round(vsp_p['mag'], 5)},{round(vsp_p['mag_err'], 5)},"
+                f.write(f"{self.auid},{round(vsp_p['time'], 5)},{round(vsp_p['mag'], 5)},{round(vsp_p['mag_err'], 4)},"
                         f"{self.i_dict['filter']},NO,STD,{vsp_p['cname']},{round(vsp_p['cmag'], 5)},na,na," 
-                        f"{round(vsp_p['airmass'], 7)},na,{self.chart_id},na\n")
+                        f"{round(vsp_p['airmass'], 5)},na,{self.chart_id},na\n")
 
 
 def aavso_dicts(planet_dict, fit, info_dict, durs, ld0, ld1, ld2, ld3):


### PR DESCRIPTION
issue #1364 
changed mag_err from 5 to 4
changed airmass round from 7 to 5

Bot changes are needed because AAVSO is rolling out a new tool to upload photometry data replacing webObs. In that new tool the AID format changed a bit. If we try to upload a current AID file created by Exotic we got the following errors:
```
Row 1: (Airmass) Ensure this value has at most 7 characters (it has 9).
Row 1: (Magnitude Error) Ensure this value has at most 6 characters (it has 7).
```