### PR TITLE
Switch to new AAVSO API URLs

### DIFF
--- a/docs/regions/English/How-to-select-comparision-stars-using-AAVSO-Star-Charts.txt
+++ b/docs/regions/English/How-to-select-comparision-stars-using-AAVSO-Star-Charts.txt
@@ -2,15 +2,15 @@ AAVSO Comparison star charts
 
 1. Getting the charts
 
-   the main URL is https://app.aavso.org/vsp/
+   the main URL is https://apps.aavso.org/vsp/
 
  you can go directly to the chart for a specific star by looking up the chart id in the lists that are periodically posted to the Slack channel and forming the URL as
 
-       https://app.aavso.org/vsp/chart/?chartid=(the listed chartid)
+       https://apps.aavso.org/vsp/chart/?chartid=(the listed chartid)
 
 Example, fot HAT-P-23
 
-      https://app.aavso.org/vsp/chart/?chartid=X26350XQ
+      https://apps.aavso.org/vsp/chart/?chartid=X26350XQ
 
 You can also go to the main URL and use the full search capabilities. You can search by star name or by RA and Dec. There is a help available (https://www.aavso.org/sites/default/files/VSP_Help.pdf)
 

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -838,7 +838,7 @@ def query_variable_star_apis(ra, dec):
 @retry(stop=stop_after_delay(30))
 def vsx_auid(ra, dec, radius=0.01, maglimit=14):
     try:
-        url = f"https://www.aavso.org/vsx/index.php?view=api.list&ra={ra}&dec={dec}&radius={radius}&tomag={maglimit}&format=json"
+        url = f"https://vsx.aavso.org/index.php?view=api.list&ra={ra}&dec={dec}&radius={radius}&tomag={maglimit}&format=json"
         result = requests.get(url)
         return result.json()['VSXObjects']['VSXObject'][0]['AUID']
     except Exception:
@@ -849,7 +849,7 @@ def vsx_auid(ra, dec, radius=0.01, maglimit=14):
 @retry(stop=stop_after_delay(30))
 def vsx_variable(ra, dec, radius=0.01, maglimit=14):
     try:
-        url = f"https://www.aavso.org/vsx/index.php?view=api.list&ra={ra}&dec={dec}&radius={radius}&tomag={maglimit}&format=json"
+        url = f"https://vsx.aavso.org/index.php?view=api.list&ra={ra}&dec={dec}&radius={radius}&tomag={maglimit}&format=json"
         result = requests.get(url)
         var = result.json()['VSXObjects']['VSXObject'][0]['Category']
 
@@ -972,7 +972,7 @@ def vsp_query(file, axis, obs_filter, img_scale, maglimit=14, user_comp_stars=No
     if fov > 180 and maglimit > 12:
         maglimit = 12
 
-    url = f"https://www.aavso.org/apps/vsp/api/chart/?format=json&ra={ra:5f}&dec={dec:5f}&fov={fov}&maglimit={maglimit}"
+    url = f"https://apps.aavso.org/vsp/api/chart/?format=json&ra={ra:5f}&dec={dec:5f}&fov={fov}&maglimit={maglimit}"
     result = requests.get(url)
     data = result.json()
     chart_id = data['chartid']

--- a/exotic/exotic_gui.py
+++ b/exotic/exotic_gui.py
@@ -272,7 +272,7 @@ def main():
 
             comppos_label = tk.Label(root, text="Comparison Star(s) X & Y Pixel Position(s)\n    "
                                                 "(Note: You can use the AAVSO's VSP to help you find\n    "
-                                                "good comparison stars: https://app.aavso.org/vsp/)",
+                                                "good comparison stars: https://apps.aavso.org/vsp/)",
                                      justify=tk.LEFT)
             comppos_entry = tk.Entry(root, font="Helvetica 12", justify=tk.LEFT)
             comppos_entry.insert(tk.END, "[x, y]")
@@ -811,7 +811,7 @@ def main():
 
                 comppos_label = tk.Label(root, text="Comparison Star(s) X & Y Pixel Position(s)\n    "
                                                     "(Note: You can use the AAVSO's VSP to help you find\n    "
-                                                    "good comparison stars: https://app.aavso.org/vsp/)",
+                                                    "good comparison stars: https://apps.aavso.org/vsp/)",
                                          justify=tk.LEFT)
                 comppos_entry = tk.Entry(root, font="Helvetica 12", justify=tk.LEFT)
                 comppos_entry.insert(tk.END, "[x1, y1], [x2, y2]")


### PR DESCRIPTION
This is in response to announced change in AAVSO API URLs, due to come into effect on 2025/05/31.  I've tested these with current state of the APIs - the new URLs do appear to be live, at present - but we probably should wait to integrate these until they have completed their update and I can test again with them in their new updated state.

The existing APIs are expected to work for some time - the 'requests' package does handle 301 redirects transparently, and it appears that the updated code is compatible enough to not require additional changes - but AAVSO has indicated that the redirects are temporary.