### PR TITLE
Fix issue 1255

### DIFF
--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -1943,6 +1943,10 @@ def main():
         if not args.override:
             nea_obj = NASAExoplanetArchive(planet=userpDict['pName'])
             userpDict['pName'], CandidatePlanetBool, pDict = nea_obj.planet_info()
+            if not pDict.get('ra') or not pDict.get('dec'):
+                log_info("NASA Archive coords missing. Falling back to inits.json RA/DEC.")
+                pDict['ra'] = userpDict.get('ra')
+                pDict['dec'] = userpDict.get('dec')
         else:
             pDict = userpDict
             CandidatePlanetBool = False

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -1943,8 +1943,11 @@ def main():
         if not args.override:
             nea_obj = NASAExoplanetArchive(planet=userpDict['pName'])
             userpDict['pName'], CandidatePlanetBool, pDict = nea_obj.planet_info()
-            # --- Fallback to user-provided RA/Dec from inits.json if NASA Exoplanet Archive
-            # returns empty coordinates (e.g., for candidate planets or API failures). ---
+            
+            # --- V2 SOTA FALLBACK (FIXED FOR CANDIDATES) ---
+            if pDict is None:
+                pDict = {}
+
             if not pDict.get('ra') or not pDict.get('dec'):
                 user_ra = userpDict.get('ra')
                 user_dec = userpDict.get('dec')
@@ -1954,8 +1957,8 @@ def main():
                     pDict['ra'] = user_ra
                     pDict['dec'] = user_dec
                 else:
-                    log_info("WARNING: NASA Archive coords missing AND no RA/DEC provided in inits.json. FOV plot may fail.")
-            # ---------------------------------
+                    log_info("WARNING: NASA Archive coords missing AND no RA/DEC provided. FOV plot may fail.")
+            # -----------------------------------------------
         else:
             pDict = userpDict
             CandidatePlanetBool = False

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -1943,10 +1943,19 @@ def main():
         if not args.override:
             nea_obj = NASAExoplanetArchive(planet=userpDict['pName'])
             userpDict['pName'], CandidatePlanetBool, pDict = nea_obj.planet_info()
+            # --- Fallback to user-provided RA/Dec from inits.json if NASA Exoplanet Archive
+            # returns empty coordinates (e.g., for candidate planets or API failures). ---
             if not pDict.get('ra') or not pDict.get('dec'):
-                log_info("NASA Archive coords missing. Falling back to inits.json RA/DEC.")
-                pDict['ra'] = userpDict.get('ra')
-                pDict['dec'] = userpDict.get('dec')
+                user_ra = userpDict.get('ra')
+                user_dec = userpDict.get('dec')
+                
+                if user_ra is not None and user_dec is not None:
+                    log_info("NASA Archive coords missing. Falling back to inits.json RA/DEC.")
+                    pDict['ra'] = user_ra
+                    pDict['dec'] = user_dec
+                else:
+                    log_info("WARNING: NASA Archive coords missing AND no RA/DEC provided in inits.json. FOV plot may fail.")
+            # ---------------------------------
         else:
             pDict = userpDict
             CandidatePlanetBool = False


### PR DESCRIPTION
This PR resolves Issue #1255 by implementing a coordinate-based fallback for the Field of View (FOV) plot.
The Problem:
When the NASAExoplanetArchive query fails (due to target omission, candidate status, or API instability), the pipeline currently fails to generate the FOV plot because of missing coordinates in pDict.
The Solution:
I have implemented a logic bridge in exotic/exotic.py that checks for user-provided RA and DEC values in userpDict (from inits.json) if the NASA Archive lookup returns empty.
Safety Features:
Utilizes .get() for safe dictionary access.
Includes a secondary check to prevent NoneType crashes if both the Archive and the user-input are missing.
Added logging to notify the user when a fallback is active.
Testing:
Verified syntax via py_compile.
Passed all 45 existing unit tests (test_ld.py and test_utils.py) using pytest on Python 3.12.
Resolves #1255
