### PR TITLE
WBoM: select the transit epoch nearest the data, fixing the one-period-early Tmid on ingress-only nights

### DIFF
--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -9865,7 +9865,12 @@ def estimate_ephemeris_tmid_and_bounds(
         return summary
 
     phases = (valid_times - prior_tmid) / period
-    cycle_index = float(np.floor(phases).max())
+    # Select the transit epoch nearest the bulk of the data. floor(phases).max()
+    # picked the transit at-or-before the last valid frame, which reports Tmid one
+    # full period early whenever the true mid falls after the last surviving frame
+    # (ingress-only partial transits, the common fixed-window case); the periodic
+    # transit model then fits perfectly at the wrong epoch. See issue #1387.
+    cycle_index = float(np.round(np.median(phases)))
     tmid = float(prior_tmid + cycle_index * period)
     propagated_uncertainty = np.sqrt(midt_unc ** 2 + (cycle_index * per_unc) ** 2)
 

--- a/tests/test_exotic_proper_motion.py
+++ b/tests/test_exotic_proper_motion.py
@@ -1848,6 +1848,35 @@ def test_estimate_ephemeris_tmid_and_bounds_keeps_wider_bounds_for_one_sided_run
     assert summary["half_width"] == pytest.approx(0.25 * prior["per"])
 
 
+def test_estimate_ephemeris_tmid_and_bounds_selects_nearest_epoch_for_ingress_only_runs():
+    # Regression for issue #1387: an ingress-only partial transit whose true mid
+    # falls minutes AFTER the last surviving frame. floor(phases).max() snapped to
+    # the previous cycle and reported Tmid one full period early; the epoch nearest
+    # the data is the correct one. Geometry taken from the 2026-07-27 TOI-1516 b
+    # MicroObservatory night that surfaced the bug (two independent reductions
+    # reported 2461246.93, one period before the actual night of the frames).
+    prior_tmid = 2458765.325
+    period = 2.056014
+    times = np.linspace(2461248.8938, 2461248.9847, 34)
+    expected_mid = prior_tmid + 1208 * period  # 2461248.9899, ~7 min after times.max()
+
+    summary = estimate_ephemeris_tmid_and_bounds(
+        times,
+        prior_tmid,
+        period,
+        midt_unc=0.00023,
+        per_unc=2.1e-6,
+        expected_duration=0.1177,
+        sigma_multiplier=25.0,
+    )
+
+    assert summary["cycle_index"] == pytest.approx(1208.0)
+    assert summary["tmid"] == pytest.approx(expected_mid, abs=1e-6)
+    # The search bounds must be able to reach the true mid.
+    assert summary["bounds"][0] <= expected_mid <= summary["bounds"][1]
+    assert summary["observations_bracket_expected_transit"] is False
+
+
 def test_is_adaptive_aperture_mode_enabled_parses_values():
     assert is_adaptive_aperture_mode_enabled(None) is False
     assert is_adaptive_aperture_mode_enabled("y") is True


### PR DESCRIPTION
Fixes #1387.

## What

`estimate_ephemeris_tmid_and_bounds` selected the transit epoch with `floor(phases).max()`: the transit at or before the last valid frame. For ingress-only partial transits, where the true mid falls after the last quality-surviving frame, that centers the Tmid search bounds one full period early. The transit model is periodic, so the sampler fits the data perfectly at the wrong epoch: every phase-folded plot looks right, and only the absolute Tmid, and its downstream uses (AAVSO submission, O–C, TTV), carries the error.

This PR changes the selector to `round(median(phases))`: the epoch nearest the bulk of the data.

## Why this selector

- **Ingress-only** (mid after last frame): floor snaps to the previous cycle; nearest-to-median picks the correct one.
- **Full transits** (mid inside data): identical to floor, verified against the existing bracketed-run test and on a real full-transit night (CoRoT-2 2026-06-30).
- **Edge-frame insensitivity**: with floor, whether Tmid is right depends on which frames survive quality rejection (the TOI-1516 directory's raw tail extends past the mid; the trimmed tail does not). Median is insensitive to edge trimming.
- **Egress-only** (mid before first frame) is the mirror case and is also handled: floor gets it right by accident there, and nearest-to-median agrees.

## Validation

Regression test added (`test_estimate_ephemeris_tmid_and_bounds_selects_nearest_epoch_for_ingress_only_runs`) using the geometry of the night that surfaced the bug. Both pre-existing tests for this function pass unchanged. The two failures in `test_exotic_proper_motion.py` (`*windows*`) pre-exist on the branch tip and are unrelated (platform-specific, run on Linux).

End-to-end on the actual 2026-07-27 TOI-1516 b MicroObservatory directory (34 surviving frames, ingress-only):

| | reported Tmid (BJD_TDB) |
|---|---|
| WBoM at branch tip (my run) | 2461246.85 ± 0.056 |
| WBoM at branch tip (Richard Jaworski's independent run) | 2461246.9247 ± 0.0052 |
| **this PR** | 2461249.019 ± 0.02 (correct cycle) |
| ephemeris-predicted mid for the actual night | 2461248.9899 |

Full-transit controls: on the real frame times of two full-transit nights (HAT-P-27 b 2026-07-06, 63 frames; CoRoT-2 b 2026-06-30, 80 frames), `floor(phases).max()` and `round(median(phases))` select the identical cycle index (1988 and 2030 respectively); the change is a no-op for the full-transit geometry.

Note the night itself remains a QC FAIL (KTMF ~1.1, egress unobserved): the fix corrects the epoch label, not the observability of the transit. The point is that the label is now in the right cycle for any partial-transit night that does pass QC.
