### PR TITLE
Fix silently wrong BJD_TDB when -ov and -nea are combined

### DIFF
--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -21399,6 +21399,20 @@ def process_flat_frames(flat_files, master_bias=None):
 def convert_jd_to_bjd(non_bjd, p_dict, info_dict):
     global _BJD_FALLBACK_WARNING_LOGGED
 
+    # Coerce sexagesimal-string coordinates to numeric degrees before any
+    # conversion. If a caller path delivers RA as "HH:MM:SS.ss" (the -ov -nea
+    # flag combination did exactly this, see issue), barycorrpy raises a
+    # TypeError and the astropy fallback below would silently parse the RA
+    # string as DEGREES (19:27:06 -> 19.45 deg instead of 291.78 deg),
+    # computing the barycentric correction for a point far away on the sky
+    # and shifting BJD_TDB by hundreds of seconds.
+    p_dict = dict(p_dict)
+    if isinstance(p_dict.get('ra'), str) or isinstance(p_dict.get('dec'), str):
+        p_dict['ra'], p_dict['dec'] = radec_hours_to_degree(
+            p_dict.get('ra'), p_dict.get('dec'), non_interactive_run=True,
+            target_name=p_dict.get('pName'),
+        )
+
     try:
         goodTimes = JDUTC_to_BJDTDB(non_bjd, ra=p_dict['ra'], dec=p_dict['dec'], lat=info_dict['lat'],
                                     longi=info_dict['long'], alt=info_dict['elev'])[0]
@@ -31076,7 +31090,11 @@ def _main_impl():
             CandidatePlanetBool = False
 
         if file_cmd_opt == 2:
-            if args.nasaexoarch:
+            # -nea combined with -ov: the override wins the data choice above
+            # (pDict = userpDict, sexagesimal strings), so the coordinate
+            # conversion must still run or string RA/Dec reach the time
+            # conversion and airmass code unconverted.
+            if args.nasaexoarch and not args.override:
                 pass
             elif args.override:
                 try:

--- a/tests/test_radec_non_interactive.py
+++ b/tests/test_radec_non_interactive.py
@@ -73,3 +73,28 @@ def test_invalid_target_coordinates_abort_when_archive_coordinates_unavailable(m
             non_interactive_run=True,
             target_name='Example b',
         )
+
+
+def test_convert_jd_to_bjd_coerces_sexagesimal_strings():
+    """Regression: with -ov -nea the main flow used to deliver sexagesimal
+    RA/Dec STRINGS to convert_jd_to_bjd. barycorrpy then raised TypeError and
+    the astropy fallback parsed "19:27:06.50" as 19.45 DEGREES instead of
+    19h27m = 291.78 degrees, silently shifting BJD_TDB by hundreds of seconds
+    (-538 s for these CoRoT-2 coordinates). String and numeric inputs must
+    produce the identical, correct conversion."""
+    site = {'lat': 31.68, 'long': -110.88, 'elev': 1268.0}
+    epochs = [2461222.65]
+
+    from_strings = exotic_module.convert_jd_to_bjd(
+        epochs, {'ra': '19:27:06.50', 'dec': '+01:23:01.5'}, site)
+    from_degrees = exotic_module.convert_jd_to_bjd(
+        epochs, {'ra': 291.777083, 'dec': 1.383750}, site)
+
+    import numpy as np
+    a = float(np.atleast_1d(from_strings)[0])
+    b = float(np.atleast_1d(from_degrees)[0])
+    assert a == pytest.approx(b, abs=1e-8)
+    # The correct value is ~ +522.5 s after the input JD_UTC (TDB-UTC ~ +69 s
+    # plus ~ +453 s light travel time for this geometry); the broken fallback
+    # produced a value ~16 s BEFORE it. Guard the sign and scale.
+    assert (a - epochs[0]) * 86400 == pytest.approx(522.5, abs=2.0)


### PR DESCRIPTION
Fixes #1390.

Root fix: the coordinate-conversion dispatch now runs `radec_hours_to_degree` when both flags are set (`-nea` alone and `-ov` alone unchanged). Defensive fix: `convert_jd_to_bjd` coerces string coordinates before any conversion, so any future path delivering strings converts correctly or fails loudly instead of silently mis-parsing hours as degrees in the astropy fallback.

Verified: string and numeric inputs now agree to 0.000000 s, barycorrpy handles the conversion (no fallback warning), and the regression test pins both the agreement and the absolute +522.5 s offset for the CoRoT-2 geometry so a sign error can't return. Full measurement table and cause chain in #1390. Test suites: only the two pre-existing `*windows*` failures, unrelated (platform-specific, run on Linux).