### PR TITLE
VSP auto-added comparison stars must sit 5% clear of frame edges

### DIFF
--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -17881,8 +17881,7 @@ def vsp_query(file, axis, obs_filter, img_scale, maglimit=14, user_comp_stars=No
             ra_pixel = float(np.asarray(ra_pix, dtype=float).reshape(-1)[0])
             dec_pixel = float(np.asarray(dec_pix, dtype=float).reshape(-1)[0])
             if not (
-                1 < ra_pixel < axis[0]
-                and 1 < dec_pixel < axis[1]
+                vsp_candidate_clear_of_edges(ra_pixel, dec_pixel, axis)
                 and obs_filter in [band['band'] for band in star['bands']]
             ):
                 continue
@@ -18079,6 +18078,32 @@ def merge_aavso_vsp_v_calibration_fallback(
             "comparison-star calibration pool."
         )
     return unified_calibrations, vsp_calibrations, chart_id, True
+
+
+# Fraction of each frame dimension that a VSP-added comparison star must sit
+# clear of every edge. Auto-added comps near an edge track out of the frame
+# under ordinary MicroObservatory pointing drift (tens of pixels per night is
+# routine; ~70-150 px has been measured on real EpW nights), and a comparison
+# that leaves the frame mid-series fails photometry after having already been
+# accepted. 5% of a 650x500 MObs frame keeps candidates >=32 px from the x
+# edges and >=25 px from the y edges.
+VSP_COMPARISON_EDGE_MARGIN_FRACTION = 0.05
+
+
+def vsp_candidate_clear_of_edges(ra_pixel, dec_pixel, axis,
+                                 margin_fraction=VSP_COMPARISON_EDGE_MARGIN_FRACTION):
+    """True when the candidate sits at least margin_fraction of each dimension
+    away from every frame edge."""
+    try:
+        x = float(ra_pixel)
+        y = float(dec_pixel)
+        x_size = float(axis[0])
+        y_size = float(axis[1])
+    except (TypeError, ValueError, IndexError):
+        return False
+    x_margin = x_size * margin_fraction
+    y_margin = y_size * margin_fraction
+    return (x_margin <= x <= x_size - x_margin) and (y_margin <= y <= y_size - y_margin)
 
 
 def add_vsp_star(vsp_star_count, user_comp_stars, vsp_star):

--- a/tests/test_vsp_edge_margin.py
+++ b/tests/test_vsp_edge_margin.py
@@ -1,0 +1,54 @@
+"""Regression test for the VSP comparison-star edge margin.
+
+Motivating failure (Exoplanet Watch, 2026-08-17): on a 650x500
+MicroObservatory night that drifted ~73 px in y, the VSP fallback
+auto-added a comparison star at [99, 1] - one pixel from the frame
+edge. The old filter accepted anything more than 1 px inside the
+frame; the comp left the frame almost immediately under drift and
+the reduction failed after the star had already been accepted.
+Comps must now sit at least 5% of each dimension from every edge.
+"""
+from exotic.exotic import (
+    VSP_COMPARISON_EDGE_MARGIN_FRACTION,
+    vsp_candidate_clear_of_edges,
+)
+
+AXIS = (650, 500)  # standard MicroObservatory frame
+
+
+def test_margin_fraction_is_five_percent():
+    assert VSP_COMPARISON_EDGE_MARGIN_FRACTION == 0.05
+
+
+def test_motivating_case_rejected():
+    # The star that broke the 2026-08-16 CoRoT-2 reduction.
+    assert not vsp_candidate_clear_of_edges(99, 1, AXIS)
+
+
+def test_frame_center_accepted():
+    assert vsp_candidate_clear_of_edges(325, 250, AXIS)
+
+
+def test_exactly_on_margin_accepted():
+    assert vsp_candidate_clear_of_edges(32.5, 25.0, AXIS)
+    assert vsp_candidate_clear_of_edges(650 - 32.5, 500 - 25.0, AXIS)
+
+
+def test_just_inside_old_filter_now_rejected():
+    # Would have passed the old (1 < x < axis) test.
+    assert not vsp_candidate_clear_of_edges(2, 250, AXIS)
+    assert not vsp_candidate_clear_of_edges(325, 499, AXIS)
+
+
+def test_all_four_edges_enforced():
+    assert not vsp_candidate_clear_of_edges(10, 250, AXIS)   # left
+    assert not vsp_candidate_clear_of_edges(645, 250, AXIS)  # right
+    assert not vsp_candidate_clear_of_edges(325, 5, AXIS)    # bottom
+    assert not vsp_candidate_clear_of_edges(325, 495, AXIS)  # top
+
+
+def test_garbage_inputs_rejected_not_raised():
+    assert not vsp_candidate_clear_of_edges(None, 250, AXIS)
+    assert not vsp_candidate_clear_of_edges(325, 250, None)
+    assert not vsp_candidate_clear_of_edges("x", 250, AXIS)
+    assert not vsp_candidate_clear_of_edges(325, 250, (650,))


### PR DESCRIPTION
As requested in-channel ("comp stars perhaps need to not be within 5% of the edge of the frame... do a pull request... Old leaf head that is") — here it is.

**Motivating case:** Amadeus's 2026-08-16 CoRoT-2 run. After the VSX check correctly removed a variable comp, the VSP fallback auto-added `[99, 1]` — one pixel from the frame edge — on a night whose field drifts ~73 px in y (measured between my solved first/last frames of the same directory). The comp exits the frame under drift and the reduction errors after the star was already accepted. Old filter: `1 < pixel < axis`.

**Change:** candidates must clear every edge by `VSP_COMPARISON_EDGE_MARGIN_FRACTION = 0.05` of that dimension (named constant; ≥32 px in x, ≥25 px in y on a 650×500 MObs frame). Implemented as a small helper with garbage-input safety, applied at the existing in-frame filter — one call site, no behavior change for interior candidates.

**Tests:** `tests/test_vsp_edge_margin.py` pins the motivating coordinates, the exact margin boundary (accepted at the line, rejected inside it), all four edges independently, and non-numeric/None inputs returning False rather than raising. 7 passed against the current tip (`fcd35c8`; branch is cut from it as of this hour).

One judgment call to flag: the margin applies to VSP **auto-added** candidates only — user-supplied comps are untouched, since a human placing a comp near an edge may know their frames don't drift. If you'd rather warn on those too, happy to extend.