### PR TITLE
numpy 2: fix the three np.NaN survivors in elca.binner

### DIFF
--- a/exotic/api/elca.py
+++ b/exotic/api/elca.py
@@ -645,13 +645,13 @@ def time_bin(time, flux, dt=1. / (60 * 24)):
 def binner(arr, n, err=''):
     if len(err) == 0:
         ecks = np.pad(arr.astype(float), (0, ((n - arr.size % n) % n)), mode='constant',
-                      constant_values=np.NaN).reshape(-1, n)
+                      constant_values=np.nan).reshape(-1, n)
         arr = bn.nanmean(ecks, axis=1)
         return arr
     else:
         ecks = np.pad(arr.astype(float), (0, ((n - arr.size % n) % n)), mode='constant',
-                      constant_values=np.NaN).reshape(-1, n)
-        why = np.pad(err.astype(float), (0, ((n - err.size % n) % n)), mode='constant', constant_values=np.NaN).reshape(
+                      constant_values=np.nan).reshape(-1, n)
+        why = np.pad(err.astype(float), (0, ((n - err.size % n) % n)), mode='constant', constant_values=np.nan).reshape(
             -1, n)
         weights = 1. / (why ** 2.)
         # Calculate the weighted average


### PR DESCRIPTION
Follow-up to d0e24d9 ("Update to 3.13 and blowback from it") and issue #1403.

The migration caught `np.product` and `np.trapz` but three `np.NaN` remained in `elca.binner` (both padding sites). On the new requirements floor (numpy>=2.5.2) every `binner()` call raises `AttributeError: np.NaN was removed in the NumPy 2.0 release` — that's the light-curve binning path, so fits/plots die at runtime even though the install now succeeds.

Receipt on current tip (fresh venv, py3.12, numpy 2.5.2):
```
>>> binner(np.arange(10.0), 3)
AttributeError: np.NaN was removed in the NumPy 2.0 release. Use np.nan instead.
```
With this 3-character fix ×3, both the unweighted and weighted branches run clean.

Also ran the full removed-alias sweep against tip (float_/NaN/infty/alltrue/product/trapz/row_stack/in1d/ptp-method/newbyteorder/...): these three lines were the only survivors. Full numpy-2 validation reduction (same-night A/B against the numpy-1.26 stack) running now; results will go to #1403.