### PR TITLE
Reject comparison stars that drift off the frame in more than 10% of the images

### DIFF
--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -311,6 +311,15 @@ COMPARISON_STAR_MIN_COVERAGE_FRACTION = 0.8
 COMPARISON_STAR_MIN_VALID_FRAMES = 5
 COMPARISON_STAR_COVERAGE_SIGMA = 3.0  # Legacy constant; coverage rejection is fraction-based.
 COMPARISON_STAR_COVERAGE_MAX_ITERS = 10
+# A comparison star that is off the frame in more than this fraction of the
+# series is dropped as a reference. "Off the frame" per frame means either the
+# centroid could not be placed inside the image at all (the PlateStatus
+# out-of-frame flag) or the widest science aperture the pipeline would try
+# (APERTURE_SIGMA_MAX * sigma) crosses an image edge, which truncates the
+# aperture sum silently. Pointing drift of ~70-150 px per night is routine on
+# MicroObservatory, so an edge comp can be measurable for most of a series and
+# still walk out of the frame for the tail of it.
+COMPARISON_STAR_MAX_OFF_FRAME_FRACTION = 0.10
 COMPARISON_STAR_SUITABILITY_OUTLIER_SIGMA = 4.25
 COMPARISON_STAR_SUITABILITY_MIN_CANDIDATES = 5
 COMPARISON_STAR_SUITABILITY_MAX_ITERS = 10
@@ -10018,15 +10027,38 @@ def psf_quality_rows_for_key(psf_data, key, psf_flux_data=None):
     return None
 
 
+def comparison_star_off_frame_key(key):
+    return f"{key}_off_frame"
+
+
+def comparison_star_off_frame_frames(psf_data, key, frame_count):
+    """Per-frame True where the star was recorded as off the frame (or its
+    whole series was rejected for drift); all False when nothing is recorded."""
+    frame_count = int(frame_count)
+    if not isinstance(psf_data, dict):
+        return np.zeros(frame_count, dtype=bool)
+    stored = psf_data.get(comparison_star_off_frame_key(key))
+    if stored is None:
+        return np.zeros(frame_count, dtype=bool)
+    try:
+        stored = np.asarray(stored, dtype=bool).reshape(-1)
+    except (TypeError, ValueError):
+        return np.zeros(frame_count, dtype=bool)
+    if stored.shape[0] != frame_count:
+        return np.zeros(frame_count, dtype=bool)
+    return stored
+
+
 def psf_quality_mask_for_key(psf_data, key, frame_count, psf_flux_data=None):
+    off_frame = comparison_star_off_frame_frames(psf_data, key, frame_count)
     rows = psf_quality_rows_for_key(psf_data, key, psf_flux_data=psf_flux_data)
     if rows is None:
-        return np.ones(int(frame_count), dtype=bool)
+        return ~off_frame
 
     mask = psf_frame_quality_mask(rows)
     if mask.shape[0] != int(frame_count):
-        return np.ones(int(frame_count), dtype=bool)
-    return mask
+        return ~off_frame
+    return mask & ~off_frame
 
 
 def target_psf_quality_rows(psf_data, psf_flux_data=None):
@@ -28595,6 +28627,168 @@ def build_relative_comparison_ensemble_series(target_flux, target_flux_error,
     }
 
 
+def comparison_star_off_frame_mask(psf_rows, image_shape, fallback_sigma=np.nan, flagged_frames=None):
+    """Per-frame True when a comparison star was off the frame.
+
+    A frame counts as off the frame when the PlateStatus out-of-frame flag was
+    raised for it (the centroid seed fell outside the image, so no PSF row
+    exists) or when the fitted centroid sits closer to an edge than the widest
+    science aperture (APERTURE_SIGMA_MAX * sigma), where photutils truncates
+    the aperture sum silently. Frames whose PSF fit failed for other reasons
+    (clouds, low flux) are not counted; those already fall out through the
+    quality mask and the coverage rule."""
+    rows = np.asarray(psf_rows, dtype=float)
+    frame_count = 0 if rows.ndim == 0 else int(rows.shape[0])
+    off_frame = np.zeros(frame_count, dtype=bool)
+    if flagged_frames is not None:
+        try:
+            flagged = np.asarray(flagged_frames, dtype=bool).reshape(-1)
+        except (TypeError, ValueError):
+            flagged = np.zeros(0, dtype=bool)
+        if flagged.shape[0] == frame_count:
+            off_frame |= flagged
+    if rows.ndim != 2 or rows.shape[1] < 2 or image_shape is None:
+        return off_frame
+    try:
+        height, width = int(image_shape[0]), int(image_shape[1])
+    except (TypeError, ValueError, IndexError):
+        return off_frame
+    if height <= 0 or width <= 0:
+        return off_frame
+
+    for index in range(frame_count):
+        row = rows[index]
+        x_centroid, y_centroid = row[0], row[1]
+        if not (np.isfinite(x_centroid) and np.isfinite(y_centroid)):
+            continue
+        margin = overexposure_aperture_radius_from_psf_row(row, fallback_sigma=fallback_sigma)
+        if not pixel_within_image(x_centroid, y_centroid, (height, width), margin=margin):
+            off_frame[index] = True
+    return off_frame
+
+
+def comparison_star_off_frame_summary(psf_data, comp_keys, image_shape,
+                                      fallback_sigma=np.nan,
+                                      flagged_frame_map=None,
+                                      max_fraction=COMPARISON_STAR_MAX_OFF_FRAME_FRACTION,
+                                      skip_rejection=False):
+    """Count off-frame frames per comparison star and decide which to drop.
+
+    Returns {key: {'off_frame_mask', 'off_frame_count', 'total_frame_count',
+    'off_frame_fraction', 'max_fraction', 'rejected'}}. A star is rejected when
+    its off-frame fraction exceeds max_fraction, unless that would leave no
+    comparison star at all; then the least-affected star is kept so the run
+    can continue and the later coverage and stability checks judge it."""
+    summary = {}
+    flagged_frame_map = flagged_frame_map if isinstance(flagged_frame_map, dict) else {}
+    for key in comp_keys:
+        rows = psf_data.get(key) if isinstance(psf_data, dict) else None
+        if rows is None:
+            continue
+        mask = comparison_star_off_frame_mask(
+            rows,
+            image_shape,
+            fallback_sigma=fallback_sigma,
+            flagged_frames=flagged_frame_map.get(key),
+        )
+        total = int(mask.shape[0])
+        count = int(np.count_nonzero(mask))
+        fraction = (count / total) if total > 0 else 0.0
+        summary[key] = {
+            'off_frame_mask': mask,
+            'off_frame_count': count,
+            'total_frame_count': total,
+            'off_frame_fraction': float(fraction),
+            'max_fraction': float(max_fraction),
+            'rejected': False,
+        }
+
+    if skip_rejection or not summary:
+        return summary
+
+    over_limit = [key for key, entry in summary.items() if entry['off_frame_fraction'] > float(max_fraction)]
+    if over_limit and len(over_limit) == len(summary):
+        keep = min(summary, key=lambda key: (summary[key]['off_frame_fraction'], key))
+        over_limit = [key for key in over_limit if key != keep]
+        summary[keep]['kept_as_last_comparison'] = True
+    for key in over_limit:
+        summary[key]['rejected'] = True
+    return summary
+
+
+def apply_comparison_star_off_frame_summary(psf_data, summary):
+    """Record the per-frame off-frame masks in psf_data so every downstream
+    quality mask excludes those frames; a rejected star has every frame
+    excluded, which removes it from the comparison pool."""
+    if not isinstance(psf_data, dict):
+        return
+    for key, entry in summary.items():
+        mask = np.asarray(entry['off_frame_mask'], dtype=bool).copy()
+        if entry.get('rejected'):
+            mask[:] = True
+        psf_data[comparison_star_off_frame_key(key)] = mask
+
+
+def format_comp_star_off_frame_text(entry):
+    return (
+        f"off the frame in {entry['off_frame_count']} of {entry['total_frame_count']} frame(s) "
+        f"({100.0 * entry['off_frame_fraction']:.1f}%; limit {100.0 * entry['max_fraction']:.1f}%)"
+    )
+
+
+def log_comparison_star_off_frame_summary(summary, labels=None):
+    labels = labels if isinstance(labels, dict) else {}
+    if summary and all(entry['off_frame_count'] == 0 for entry in summary.values()):
+        sample = next(iter(summary.values()))
+        log_info(
+            f"Comparison-star drift check: no comparison star left the frame in any of "
+            f"{sample['total_frame_count']} frame(s) (limit {100.0 * sample['max_fraction']:.1f}%)."
+        )
+        return
+    for key in summary:
+        entry = summary[key]
+        if entry['off_frame_count'] == 0:
+            continue
+        default_label = f"Comparison star #{key[4:]}" if key.startswith('comp') else key
+        label = labels.get(key) or default_label
+        if entry.get('rejected'):
+            log_info(
+                f"{label} rejected as a comparison star: {format_comp_star_off_frame_text(entry)}. "
+                "Its photometry will not be used as a reference.",
+                warn=True,
+            )
+        elif entry.get('kept_as_last_comparison'):
+            log_info(
+                f"{label} is {format_comp_star_off_frame_text(entry)} but is kept because every "
+                "comparison star exceeded the limit; those frames are excluded from its photometry.",
+                warn=True,
+            )
+        else:
+            log_info(
+                f"{label}: {format_comp_star_off_frame_text(entry)}; those frames are excluded "
+                "from its photometry."
+            )
+
+
+def comparison_star_out_of_frame_flags(plate_status, filenames, comp_keys):
+    """Per-comparison-star bool arrays of the PlateStatus out-of-frame flags,
+    in the order of the reduced filenames."""
+    status_by_filename = getattr(plate_status, 'statusByFilename', None)
+    if not isinstance(status_by_filename, dict):
+        return {}
+    filenames = [str(name) for name in filenames]
+    flags = {}
+    for key in comp_keys:
+        if not (key.startswith('comp') and key[4:].isdigit()):
+            continue
+        errorcode = f"outofframe_{key}"
+        flags[key] = np.array(
+            [bool(status_by_filename.get(name, {}).get(errorcode, False)) for name in filenames],
+            dtype=bool,
+        )
+    return flags
+
+
 def comparison_star_coverage_summary(comp_flux_map,
                                      min_fraction=COMPARISON_STAR_MIN_COVERAGE_FRACTION,
                                      min_points=COMPARISON_STAR_MIN_VALID_FRAMES,
@@ -36172,6 +36366,7 @@ def _main_impl():
                 # x-cent, y-cent, amplitude, sigma-x, sigma-y, rotation, offset
                 'target': np.zeros((len(inputfiles), 7)),  # PSF fit
             }
+            science_frame_shape = None
             psf_flux_data = {
                 'target': np.zeros((len(inputfiles), 7)),
             }
@@ -36795,6 +36990,8 @@ def _main_impl():
 
                 if i == 0 and multiprocess_alignment_results is None:
                     firstImage = np.copy(imageData)
+                if i == 0:
+                    science_frame_shape = tuple(int(axis) for axis in np.shape(imageData)[:2])
 
                 if multiprocess_alignment_results is not None:
                     if not multiprocess_alignment_results_applied:
@@ -37247,6 +37444,27 @@ def _main_impl():
                 f"{perf_counter() - initial_photometry_start:.2f}s."
             )
             plateStatus.logAggregatedWarningSummary()
+
+            # Comparison stars that drifted off the frame. VSX targets tracked
+            # through comp keys are measured, not used as references, so they
+            # are left out of the pool that can be rejected.
+            reference_comp_keys = [
+                comp_key for comp_key in comp_alignment_keys
+                if comp_key not in tracked_vsx_labels
+            ]
+            comp_off_frame_summary = comparison_star_off_frame_summary(
+                psf_data,
+                reference_comp_keys,
+                science_frame_shape,
+                fallback_sigma=sigma,
+                flagged_frame_map=comparison_star_out_of_frame_flags(
+                    plateStatus, inputfiles, reference_comp_keys,
+                ),
+                skip_rejection=use_exactly_the_comps_provided,
+            )
+            apply_comparison_star_off_frame_summary(psf_data, comp_off_frame_summary)
+            log_comparison_star_off_frame_summary(comp_off_frame_summary)
+
             timing_mode_label = 'Quick Look' if quick_look_mode else 'full reduction'
             log_transform_timing_stats(f'Transformation timing summary ({timing_mode_label})')
             log_photometry_timing_stats(f'Photometry timing summary ({timing_mode_label})')

--- a/tests/test_comp_star_off_frame_rejection.py
+++ b/tests/test_comp_star_off_frame_rejection.py
@@ -1,0 +1,188 @@
+"""Comparison stars that drift off the frame in more than 10% of the images
+are dropped as references; frames where a kept comp is off the frame are
+excluded from its photometry.
+
+Motivating case (Exoplanet Watch, 2026-08 MicroObservatory nights): pointing
+drift of ~70-150 px per night walks an edge comparison star out of the frame
+for the tail of a series. For those frames the centroid may still fit, but
+the science aperture crosses the edge and photutils returns a truncated sum
+that is finite and positive, so the flux-based coverage rule never sees it.
+"""
+import numpy as np
+
+from exotic.exotic import (
+    APERTURE_SIGMA_MAX,
+    COMPARISON_STAR_MAX_OFF_FRAME_FRACTION,
+    apply_comparison_star_off_frame_summary,
+    comparison_star_off_frame_mask,
+    comparison_star_off_frame_summary,
+    comparison_star_out_of_frame_flags,
+    psf_quality_mask_for_key,
+)
+from exotic.plate_status import PlateStatus
+
+FRAME_SHAPE = (500, 650)  # (height, width) of a MicroObservatory frame
+SIGMA = 2.0
+
+
+def _rows(x_values, y_values, sigma=SIGMA):
+    rows = np.zeros((len(x_values), 7), dtype=float)
+    rows[:, 0] = x_values
+    rows[:, 1] = y_values
+    rows[:, 2] = 1000.0
+    rows[:, 3] = sigma
+    rows[:, 4] = sigma
+    return rows
+
+
+def _drifting_rows(frame_count, x_start, drift_per_frame, y=250.0):
+    x_values = x_start + drift_per_frame * np.arange(frame_count)
+    return _rows(x_values, np.full(frame_count, y))
+
+
+def test_limit_is_ten_percent():
+    assert COMPARISON_STAR_MAX_OFF_FRAME_FRACTION == 0.10
+
+
+def test_mask_flags_frames_where_widest_aperture_crosses_an_edge():
+    margin = APERTURE_SIGMA_MAX * SIGMA
+    rows = _rows(
+        [325.0, margin + 0.5, margin - 0.5, 650.0 - margin - 0.5, 650.0 - margin + 0.5, 325.0],
+        [250.0, 250.0, 250.0, 250.0, 250.0, margin - 0.5],
+    )
+    mask = comparison_star_off_frame_mask(rows, FRAME_SHAPE)
+    assert mask.tolist() == [False, False, True, False, True, True]
+
+
+def test_mask_counts_plate_status_flags_but_not_other_fit_failures():
+    rows = _rows([325.0, np.nan, np.nan], [250.0, np.nan, np.nan])
+    flagged = np.array([False, True, False])
+    mask = comparison_star_off_frame_mask(rows, FRAME_SHAPE, flagged_frames=flagged)
+    # Frame 1: seed fell outside the image (flagged). Frame 2: fit failed for
+    # some other reason and is not the drift rule's business.
+    assert mask.tolist() == [False, True, False]
+
+
+def test_comp_off_frame_in_more_than_ten_percent_is_rejected():
+    frame_count = 100
+    psf_data = {
+        'target': _drifting_rows(frame_count, 325.0, 0.0),
+        # Drifts 1 px/frame toward the right edge; with sigma 2 the widest
+        # aperture is APERTURE_SIGMA_MAX*2 px, and the last 15 frames cross it.
+        'comp1': _drifting_rows(frame_count, 650.0 - APERTURE_SIGMA_MAX * SIGMA - 84.5, 1.0),
+        'comp2': _drifting_rows(frame_count, 200.0, 1.0),
+    }
+    summary = comparison_star_off_frame_summary(psf_data, ['comp1', 'comp2'], FRAME_SHAPE)
+    assert summary['comp1']['off_frame_count'] == 15
+    assert summary['comp1']['rejected']
+    assert summary['comp2']['off_frame_count'] == 0
+    assert not summary['comp2']['rejected']
+
+
+def test_comp_off_frame_in_at_most_ten_percent_is_kept_with_those_frames_excluded():
+    frame_count = 100
+    psf_data = {
+        'target': _drifting_rows(frame_count, 325.0, 0.0),
+        'comp1': _drifting_rows(frame_count, 650.0 - APERTURE_SIGMA_MAX * SIGMA - 89.5, 1.0),
+    }
+    summary = comparison_star_off_frame_summary(psf_data, ['comp1'], FRAME_SHAPE)
+    assert summary['comp1']['off_frame_count'] == 10
+    assert not summary['comp1']['rejected']
+
+    apply_comparison_star_off_frame_summary(psf_data, summary)
+    quality = psf_quality_mask_for_key(psf_data, 'comp1', frame_count)
+    assert quality[:90].all()
+    assert not quality[90:].any()
+
+
+def test_rejected_comp_has_every_frame_excluded_downstream():
+    frame_count = 40
+    psf_data = {
+        'target': _drifting_rows(frame_count, 325.0, 0.0),
+        'comp1': _drifting_rows(frame_count, 20.0, -1.0),
+        'comp2': _drifting_rows(frame_count, 400.0, -1.0),
+    }
+    summary = comparison_star_off_frame_summary(psf_data, ['comp1', 'comp2'], FRAME_SHAPE)
+    assert summary['comp1']['rejected']
+    apply_comparison_star_off_frame_summary(psf_data, summary)
+    assert not psf_quality_mask_for_key(psf_data, 'comp1', frame_count).any()
+    # The other comp, the target and keys without a record are untouched.
+    assert psf_quality_mask_for_key(psf_data, 'comp2', frame_count).all()
+    assert psf_quality_mask_for_key(psf_data, 'target', frame_count).all()
+
+
+def test_last_comparison_star_is_never_rejected():
+    frame_count = 50
+    psf_data = {
+        'target': _drifting_rows(frame_count, 325.0, 0.0),
+        'comp1': _drifting_rows(frame_count, 20.0, -1.0),   # off for most of the series
+        'comp2': _drifting_rows(frame_count, 30.0, -1.0),   # off for a bit less of it
+    }
+    summary = comparison_star_off_frame_summary(psf_data, ['comp1', 'comp2'], FRAME_SHAPE)
+    assert summary['comp1']['off_frame_fraction'] > COMPARISON_STAR_MAX_OFF_FRAME_FRACTION
+    assert summary['comp2']['off_frame_fraction'] > COMPARISON_STAR_MAX_OFF_FRAME_FRACTION
+    assert summary['comp1']['rejected']
+    assert not summary['comp2']['rejected']
+    assert summary['comp2']['kept_as_last_comparison']
+
+
+def test_sole_comparison_star_is_kept_even_when_over_the_limit():
+    frame_count = 40
+    psf_data = {'comp1': _drifting_rows(frame_count, 20.0, -1.0)}
+    summary = comparison_star_off_frame_summary(psf_data, ['comp1'], FRAME_SHAPE)
+    assert summary['comp1']['off_frame_fraction'] > COMPARISON_STAR_MAX_OFF_FRAME_FRACTION
+    assert not summary['comp1']['rejected']
+    assert summary['comp1']['kept_as_last_comparison']
+    apply_comparison_star_off_frame_summary(psf_data, summary)
+    quality = psf_quality_mask_for_key(psf_data, 'comp1', frame_count)
+    assert quality[:11].all() and not quality[11:].any()
+
+
+def test_skip_rejection_keeps_masks_but_rejects_nothing():
+    frame_count = 40
+    psf_data = {'comp1': _drifting_rows(frame_count, 20.0, -1.0)}
+    summary = comparison_star_off_frame_summary(psf_data, ['comp1'], FRAME_SHAPE, skip_rejection=True)
+    assert summary['comp1']['off_frame_count'] > 4
+    assert not summary['comp1']['rejected']
+
+
+def test_plate_status_out_of_frame_flags_follow_file_order():
+    status = PlateStatus(lambda *args, **kwargs: None)
+    files = ['a.fits', 'b.fits', 'c.fits']
+    status.initializeFilenames(files)
+    status.initializeComparisonStarCount(2)
+    status.setCurrentFilename('b.fits')
+    status.outOfFrameWarning(2)
+    flags = comparison_star_out_of_frame_flags(status, files, ['comp1', 'comp2', 'target'])
+    assert set(flags) == {'comp1', 'comp2'}
+    assert flags['comp1'].tolist() == [False, False, False]
+    assert flags['comp2'].tolist() == [False, True, False]
+
+
+def test_log_lines_name_the_reason(monkeypatch):
+    import exotic.exotic as exotic_module
+
+    lines = []
+    monkeypatch.setattr(exotic_module, 'log_info', lambda message, **kwargs: lines.append(message))
+    frame_count = 100
+    psf_data = {
+        'comp1': _drifting_rows(frame_count, 650.0 - APERTURE_SIGMA_MAX * SIGMA - 84.5, 1.0),
+        'comp2': _drifting_rows(frame_count, 650.0 - APERTURE_SIGMA_MAX * SIGMA - 96.5, 1.0),
+        'comp3': _drifting_rows(frame_count, 325.0, 0.0),
+    }
+    summary = comparison_star_off_frame_summary(psf_data, ['comp1', 'comp2', 'comp3'], FRAME_SHAPE)
+    exotic_module.log_comparison_star_off_frame_summary(summary)
+    assert lines == [
+        "Comparison star #1 rejected as a comparison star: off the frame in 15 of 100 frame(s) "
+        "(15.0%; limit 10.0%). Its photometry will not be used as a reference.",
+        "Comparison star #2: off the frame in 3 of 100 frame(s) (3.0%; limit 10.0%); "
+        "those frames are excluded from its photometry.",
+    ]
+
+    lines.clear()
+    exotic_module.log_comparison_star_off_frame_summary(
+        comparison_star_off_frame_summary(psf_data, ['comp3'], FRAME_SHAPE)
+    )
+    assert lines == [
+        "Comparison-star drift check: no comparison star left the frame in any of 100 frame(s) (limit 10.0%).",
+    ]


### PR DESCRIPTION
Follows up on #1402 (the selection-time edge margin for VSP-added comps), per Michael's request in #exotic: a runtime rejector for comparison stars that drift off the frame in more than 10% of the images.

## What "off the frame" means here

Per frame, a comparison star counts as off the frame when either

- the PlateStatus `outofframe_compN` flag was raised for that file (the centroid seed fell outside the image, so there is no PSF row), or
- the fitted centroid sits closer to an image edge than the widest science aperture the pipeline would try (`APERTURE_SIGMA_MAX * sigma`, the same radius the overexposure check uses).

The second case is the one the existing coverage rule cannot see. `aperPhot` calls `mask.cutout(data)`, and photutils only returns `None` when the aperture is *entirely* outside the image; a partially clipped aperture returns a cutout padded with zeros, so the sum comes back finite, positive and too small. `valid_comparison_frame_mask` (`isfinite & > 0`) accepts it. Frames where the PSF fit failed for other reasons (clouds, low flux) are not counted as drift; those already fall out through the quality mask and the coverage rule.

## What changes

- New constant `COMPARISON_STAR_MAX_OFF_FRAME_FRACTION = 0.10`.
- After the initial photometry loop, `comparison_star_off_frame_summary` counts off-frame frames per reference comp from `psf_data` centroids, the first frame's shape and the PlateStatus flags. Over 10%: the comp is rejected. At or under 10%: the comp is kept and only the off-frame frames are excluded from its photometry.
- The per-frame masks are stored as `psf_data[f"{ckey}_off_frame"]` and folded into `psf_quality_mask_for_key`, which every downstream consumer (candidate jobs, calibrated-photometry selection, stability summaries, ensemble paths) already goes through. A rejected comp has every frame masked, so it drops out of the pool through the existing coverage machinery (its coverage line reads 0 valid frames; the drift line printed just before says why).
- Never rejects the last comparison star: if every comp is over the limit, the least-affected one is kept (logged as such) so the run continues and the coverage/stability/QC checks judge it.
- VSX targets tracked through comp keys are measured, not used as references, so they are left out of the pool that can be rejected. `use_exactly_the_comps_provided` skips the rejection (frames are still masked, as the existing quality masks already are under that flag).

Log lines:

```
Comparison star #2 rejected as a comparison star: off the frame in 14 of 87 frame(s) (16.1%; limit 10.0%). Its photometry will not be used as a reference.
Comparison star #3: off the frame in 3 of 87 frame(s) (3.4%; limit 10.0%); those frames are excluded from its photometry.
```

## Tests

`tests/test_comp_star_off_frame_rejection.py` (11 tests): the aperture-crossing geometry on all four edges, PlateStatus flags counted but other fit failures not, 15/100 rejected vs 10/100 kept with those frames excluded, rejected comp fully masked downstream while target and other comps are untouched, last-comp guard (two-comp and sole-comp cases), skip flag, the PlateStatus flag extraction in file order, and the exact log lines. Related suites (`test_nextastro_variability.py`, `test_exotic_proper_motion.py`, `test_vsp_edge_margin.py`) pass: 384 in total.

## End to end

Three full reductions of MicroObservatory CoRoT-2 nights on this branch (4 explicit comps, AAVSO comps off):

- **2026-08-09, 87 frames**: `Comparison-star drift check: no comparison star left the frame in any of 87 frame(s) (limit 10.0%).` Tmid 2461261.8079 +/- 0.0046, against 2461261.8082 +/- 0.0051 from the #1408 run of the same night.
- **2026-08-16, 86 frames**: no comp off the frame; Tmid 2461268.7952 +/- 0.0098 (reference for the next run).
- **2026-08-16 with the #1402 edge star added as a 5th comp at (99, 1)**: PlateStatus reports `Comparison star #5: outside the image in 85 frame(s)` (the seed was inside on frame 1, but within the aperture margin), the rejector logs `Comparison star #5 rejected as a comparison star: off the frame in 86 of 86 frame(s) (100.0%; limit 10.0%)`, its coverage line reads `coverage=0 valid frame(s) out of 86 total ... [rejected]`, and the run proceeds on the four real comps: Tmid 2461268.7947 +/- 0.0076. Before this change the same star entered the candidate pool with finite, edge-clipped photometry.

No tracebacks; the three runs took 36, 18 and 32 minutes.
