### PR TITLE
Port #1382 to the magic branch: MObs site metadata in both copies, header-driven binning, TransitLab README (#1381)

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,23 @@ For fortuitous VSX variables found during a transit reduction, `"photometer_fort
 
 `use_nextastro_vsx_cache_first` defaults to `false`. When enabled, fortuitous-variable discovery queries `https://photometry.nextastro.org/vsx_query` first. EXOTIC falls back to AAVSO when the cache fails or returns no objects. Full-schema cache responses supply period and amplitude directly; legacy cache responses are enriched from AAVSO for optimal/normal classification.
 
+## Third-Party GUI Launchers
+
+### TransitLab
+[TransitLab](https://github.com/ArtTrail/TransitLab) is a cross-platform desktop GUI launcher and workflow assistant for EXOTIC, available for Windows, macOS (Apple Silicon), and Linux. It guides observers through every step of a reduction run: loading FITS frames, image analysis, target parameter lookup via the NASA Exoplanet Archive, running EXOTIC, and submitting results to AAVSO, all from a single tabbed interface.
+
+**Features include:**
+- Automatic plate solving (astrometry.net or ASTAP)
+- NASA Exoplanet Archive integration for automatic target parameter lookup
+- AAVSO comparison star selection
+- Transit geometry visualizer with real-time animated light curve preview
+- Session history browser
+- Automation mode for unattended reductions
+- Built-in Python & EXOTIC setup wizard (install, upgrade, uninstall without the command line)
+- AAVSO submission directly from the app
+
+[Download the latest release](https://github.com/ArtTrail/TransitLab/releases/latest) | [Source code](https://github.com/ArtTrail/TransitLab)
+
 ## Features and Pipeline Architecture
 
 - Automatic Plate Solution from http://nova.astrometry.net

--- a/exotic/api/colab.py
+++ b/exotic/api/colab.py
@@ -236,7 +236,7 @@ def convert_Mobs_to_utc(datestamp, latitude, longitude, height):
 def find (hdr, ks, obs):
   # Special stuff for MObs and Boyce-Astro Observatories
   boyce = {"FILTER": "ip", "LATITUDE": "+32.6135", "LONGITUD": "-116.3334", "HEIGHT": 1405 }
-  mobs = {"FILTER": "V", "LATITUDE": "+37.04", "LONGITUD": "-110.73", "HEIGHT": 2606 }
+  mobs = {"FILTER": "CV", "LATITUDE": "+31.675467", "LONGITUD": "-110.951376", "HEIGHT": 1268}
 
   if "OBSERVAT" in hdr.keys() and hdr["OBSERVAT"] == 'Whipple Observatory':
     obs = "MObs"
@@ -311,6 +311,30 @@ def look_for_calibration(image_dir):
 # Writes a new inits file into the directory with the output plots.  This prompts
 # for needed information that it cannot find in the fits header of the first image.
 
+def pixel_binning_from_header(hdr, default="1x1"):
+  """Return the "NxM" binning string from the frame's header, else the default.
+
+  MicroObservatory frames are 2x2 binned and say so (XBINNING/YBINNING); other
+  observatories' frames carry their own values, so read them rather than
+  hardcoding one observatory's binning into the template.
+  """
+  for x_key, y_key in (("XBINNING", "YBINNING"), ("CCDXBIN", "CCDYBIN"), ("XBIN", "YBIN")):
+    x_bin = hdr.get(x_key)
+    if x_bin is None:
+      continue
+    y_bin = hdr.get(y_key, x_bin)
+    try:
+      x_bin, y_bin = int(float(x_bin)), int(float(y_bin))
+    except (TypeError, ValueError):
+      continue
+    if x_bin > 0 and y_bin > 0:
+      return f"{x_bin}x{y_bin}"
+  binning = hdr.get("BINNING")
+  if isinstance(binning, str) and re.fullmatch(r"\s*\d+\s*[xX]\s*\d+\s*", binning):
+    return binning.strip().lower()
+  return default
+
+
 def make_inits_file(planetary_params, image_dir, output_dir, first_image, targ_coords, comp_coords, obs, aavso_obs_code, sec_obs_code, sample_data):
   inits_file_path = output_dir+"inits.json"
   hdul = fits.open(first_image)
@@ -342,6 +366,7 @@ def make_inits_file(planetary_params, image_dir, output_dir, first_image, targ_c
   longitude = find(hdr,['LONGITUD', 'LONG', 'LONGITUDE', 'SITELONG'],obs)
   latitude = find(hdr,['LATITUDE', 'LAT', 'SITELAT'],obs)
   height = float(find(hdr, ['HEIGHT', 'ELEVATION', 'ELE', 'EL', 'OBSGEO-H', 'ALT-OBS', 'SITEELEV'], obs))
+  pixel_binning = pixel_binning_from_header(hdr)
   obs_notes = "N/A"
 
   mobs_data = False
@@ -382,7 +407,7 @@ def make_inits_file(planetary_params, image_dir, output_dir, first_image, targ_c
             "Obs. Longitude": "%s",
             "Obs. Elevation (meters)": %d,
             "Camera Type (CCD or DSLR)": "CCD",
-            "Pixel Binning": "1x1",
+            "Pixel Binning": "%s",
             "Filter Name (aavso.org/filters)": "%s",
             "Observing Notes": "%s",
 
@@ -423,7 +448,7 @@ def make_inits_file(planetary_params, image_dir, output_dir, first_image, targ_c
     }
 }
 """ % (planetary_params, image_dir, output_dir, flats_dir, darks_dir, biases_dir, 
-       aavso_obs_code, sec_obs_code, obs_date, latitude, longitude, height, filter, 
+       aavso_obs_code, sec_obs_code, obs_date, latitude, longitude, height, pixel_binning, filter, 
        obs_notes, targ_coords, comp_coords, min, max))
 
   display(HTML('<p class="output"><b>Initialization File Created.</b></p>'))

--- a/exotic/utils.py
+++ b/exotic/utils.py
@@ -595,7 +595,9 @@ def find(hdr, ks, obs=None):
     """
     # Special stuff for MObs and Boyce-Astro Observatories
     boyce = {"LATITUDE": "+32.6135", "LONGITUD": "-116.3334", "HEIGHT": 1405}
-    mobs = {"LATITUDE": "+37.04", "LONGITUD": "-110.73", "HEIGHT": 2606}
+    # MicroObservatory telescopes sit at the Whipple Observatory base camp
+    # (Amado, AZ), not on the Mount Hopkins summit (2606 m). See PR #1382.
+    mobs = {"LATITUDE": "+31.675467", "LONGITUD": "-110.951376", "HEIGHT": 1268}
 
     if "OBSERVAT" in hdr.keys() and hdr["OBSERVAT"] == 'Whipple Observatory':
         obs = "MObs"

--- a/tests/test_colab.py
+++ b/tests/test_colab.py
@@ -1,0 +1,96 @@
+"""Colab helper: MicroObservatory site metadata and header-driven binning.
+
+Ported from PR #1382 (S-Bhattacharya240611) onto the magic branch, with the
+pixel binning read from the frame header instead of a fixed template value.
+"""
+import importlib
+import json
+import sys
+import types
+
+import numpy as np
+import pytest
+from astropy.io import fits
+
+
+def import_colab(monkeypatch):
+    fake_barycorrpy = types.ModuleType("barycorrpy")
+    fake_barycorrpy.utc_tdb = object()
+    fake_ipython = types.ModuleType("IPython")
+    fake_display = types.ModuleType("IPython.display")
+    fake_display.display = lambda *args, **kwargs: None
+    fake_display.HTML = lambda value: value
+
+    monkeypatch.setitem(sys.modules, "barycorrpy", fake_barycorrpy)
+    monkeypatch.setitem(sys.modules, "IPython", fake_ipython)
+    monkeypatch.setitem(sys.modules, "IPython.display", fake_display)
+
+    return importlib.import_module("exotic.api.colab")
+
+
+def _mobs_frame(tmp_path, binning=(2, 2)):
+    fits_path = tmp_path / "mobs.fits"
+    fits.PrimaryHDU(data=np.zeros((2, 2))).writeto(fits_path)
+    with fits.open(fits_path, mode="update") as hdul:
+        hdr = hdul[0].header
+        hdr["OBSERVAT"] = "Whipple Observatory"
+        hdr["DATE"] = "2017-12-20T01:33:43.000"
+        hdr["WEATHER"] = 80
+        hdr["TELTEMP"] = 20.0
+        hdr["CAMTEMP"] = 10.0
+        if binning is not None:
+            hdr["XBINNING"], hdr["YBINNING"] = binning
+    return fits_path
+
+
+def test_mobs_defaults_match_exotic_metadata(monkeypatch, tmp_path):
+    colab = import_colab(monkeypatch)
+    fits_path = _mobs_frame(tmp_path)
+
+    hdr = fits.getheader(fits_path)
+    assert colab.find(hdr, ["FILTER", "FILT"], "MObs") == "CV"
+    assert colab.find(hdr, ["LATITUDE", "LAT", "SITELAT"], "MObs") == "+31.675467"
+    assert colab.find(hdr, ["LONGITUD", "LONG", "LONGITUDE", "SITELONG"], "MObs") == "-110.951376"
+    assert colab.find(hdr, ["HEIGHT", "ELEVATION", "ELE", "EL", "OBSGEO-H", "ALT-OBS", "SITEELEV"], "MObs") == 1268
+
+    inits_path = colab.make_inits_file(
+        '"planetary_parameters": {}',
+        tmp_path.as_posix(),
+        f"{tmp_path.as_posix()}/",
+        fits_path.as_posix(),
+        "[424, 286]",
+        "[[465, 183], [512, 263]]",
+        "MObs",
+        "RTZ",
+        "",
+        False,
+    )
+    with open(inits_path) as inits_file:
+        user_info = json.load(inits_file)["user_info"]
+
+    assert user_info["Filter Name (aavso.org/filters)"] == "CV"
+    assert user_info["Obs. Latitude"] == "+31.675467"
+    assert user_info["Obs. Longitude"] == "-110.951376"
+    assert user_info["Obs. Elevation (meters)"] == 1268
+    assert user_info["Pixel Binning"] == "2x2"
+    assert user_info["Secondary Observer Codes (N/A if none)"] == "MOBS"
+
+
+@pytest.mark.parametrize(
+    "cards, expected",
+    [
+        ({"XBINNING": 2, "YBINNING": 2}, "2x2"),
+        ({"XBINNING": 1, "YBINNING": 1}, "1x1"),
+        ({"XBINNING": "3"}, "3x3"),
+        ({"CCDXBIN": 2, "CCDYBIN": 4}, "2x4"),
+        ({"BINNING": "2X2"}, "2x2"),
+        ({"XBINNING": "junk"}, "1x1"),
+        ({}, "1x1"),
+    ],
+)
+def test_pixel_binning_from_header(monkeypatch, cards, expected):
+    colab = import_colab(monkeypatch)
+    hdr = fits.Header()
+    for key, value in cards.items():
+        hdr[key] = value
+    assert colab.pixel_binning_from_header(hdr) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -625,21 +625,21 @@ class TestFind:
 
         # these search keys are copied from the implementation code
         search_keys = ['LONGITUD', 'LONG', 'LONGITUDE', 'SITELONG']
-        whipple_observatory_longitude = "-110.73"
+        whipple_observatory_longitude = "-110.951376"
         result = find(hdr, search_keys)
 
         assert result == whipple_observatory_longitude
 
         # these search keys are copied from the implementation code
         search_keys = ['LATITUDE', 'LAT', 'SITELAT']
-        whipple_observatory_latitude = "+37.04"
+        whipple_observatory_latitude = "+31.675467"
         result = find(hdr, search_keys)
 
         assert result == whipple_observatory_latitude
 
         # these search keys are copied from the implementation code
         search_keys = ['HEIGHT', 'ELEVATION', 'ELE', 'EL', 'OBSGEO-H', 'ALT-OBS', 'SITEELEV']
-        whipple_observatory_height = 2606
+        whipple_observatory_height = 1268
         result = find(hdr, search_keys)
 
         assert result == whipple_observatory_height
@@ -671,12 +671,12 @@ class TestFind:
         search_keys = ['LONGITUD', 'LONG', 'LONGITUDE', 'SITELONG']
         result = find(hdr, search_keys, obs="MObs")
 
-        assert result == "-110.73"  # this value is hard coded in the function
+        assert result == "-110.951376"  # this value is hard coded in the function
 
         search_keys = ['LATITUDE', 'LAT', 'SITELAT']
         result = find(hdr, search_keys, obs="MObs")
 
-        assert result == "+37.04"  # this value is hard coded in the function
+        assert result == "+31.675467"  # this value is hard coded in the function
 
     @patch("exotic.utils.process_lat_long")
     def test_generic_hdr(self, mock_pll):
@@ -736,3 +736,22 @@ class TestFind:
         mock_get_val.assert_called_once()
         assert result == get_val_returns
         assert type(result) == int
+
+
+def test_find_uses_corrected_microobservatory_site_for_whipple_headers():
+    """The command-line path: a MicroObservatory header (OBSERVAT = Whipple
+    Observatory) must resolve to the base-camp site, not the old summit
+    constants that were ~600 km off (PR #1382 fixed the Colab copy only)."""
+    from astropy.io import fits
+
+    from exotic.utils import find
+
+    hdr = fits.Header()
+    hdr["OBSERVAT"] = "Whipple Observatory"
+    hdr["LATITUDE"] = 31.68
+    hdr["LONGITUD"] = -110.88
+    hdr["HEIGHT"] = 1268.0
+
+    assert find(hdr, ["LATITUDE", "LAT", "SITELAT"]) == "+31.675467"
+    assert find(hdr, ["LONGITUD", "LONG", "LONGITUDE", "SITELONG"]) == "-110.951376"
+    assert find(hdr, ["HEIGHT", "ELEVATION", "ELE", "EL", "OBSGEO-H", "ALT-OBS", "SITEELEV"]) == 1268


### PR DESCRIPTION
Ports #1382 (@S-Bhattacharya240611) onto this branch and carries #1381's README section (@ArtTrail), per the open-PR walkthrough with Rob.

## What was wrong

The MicroObservatory constants (`+37.04, -110.73, 2606 m`) point at the Mount Hopkins summit, ~600 km from the telescopes, which sit at the Whipple Observatory base camp (`+31.675467, -110.951376, 1268 m`). #1382 corrected the copy in `exotic/api/colab.py`. The same constants live in a second copy, `exotic/utils.py` `find()`, which the command-line path uses, and there they *override the header's own correct values* whenever `OBSERVAT == 'Whipple Observatory'`. Verified on a real 2026-08-16 Cecilia frame with the actual `inputs.latitude/longitude/elevation` resolution:

```
tip e024049:  resolved: +37.04 -110.73 2606.0      | header says: 31.68 -110.88 1268.0
this branch:  resolved: +31.675467 -110.951376 1268.0 | header says: 31.68 -110.88 1268.0
```

Scale of the effect for past reductions with blank site fields: barycentric timing error of milliseconds; airmass curve off by several percent, which the detrending mostly absorbs. Worth fixing; no one's data is invalidated.

## Changes

- `exotic/utils.py`, `exotic/api/colab.py`: corrected MObs site constants in both copies; Colab filter default `CV` as in #1382.
- `exotic/api/colab.py`: `Pixel Binning` in the generated inits is now read from the frame header (`XBINNING/YBINNING`, `CCDXBIN/CCDYBIN`, `XBIN/YBIN`, or `BINNING`), default `1x1`. This answers the open question on #1382 about Boyce-Astro frames: MObs frames say `XBINNING = 2` and get `2x2`; other observatories get their own value rather than one observatory's binning hardcoded into a shared template.
- `README.md`: the TransitLab section from #1381.
- Tests: `tests/test_colab.py` (ported from #1382, plus the binning cases), a `find()` test on a Whipple header in `tests/test_utils.py`, and the three existing assertions that pinned the old constants updated. `test_colab.py`, `test_utils.py`, `test_inputs.py`: 200 passed. A quick-look reduction of the 2026-08-09 CoRoT-2 night with blank site fields runs clean on the branch.

Deliberately unchanged: `find()` still prefers the constants over the header for MObs frames (same behaviour as before, correct values now). If the preference should flip to header-first, that is a one-line follow-up; I kept this PR to the port.
