### PR TITLE
Excise the dead Boyce-Astro site path from both find() copies

### DIFF
--- a/exotic/api/colab.py
+++ b/exotic/api/colab.py
@@ -234,20 +234,12 @@ def convert_Mobs_to_utc(datestamp, latitude, longitude, height):
 #########################################################
 
 def find (hdr, ks, obs):
-  # Special stuff for MObs and Boyce-Astro Observatories
-  boyce = {"FILTER": "ip", "LATITUDE": "+32.6135", "LONGITUD": "-116.3334", "HEIGHT": 1405 }
+  # Special stuff for MicroObservatory (MObs)
   mobs = {"FILTER": "CV", "LATITUDE": "+31.675467", "LONGITUD": "-110.951376", "HEIGHT": 1268}
 
   if "OBSERVAT" in hdr.keys() and hdr["OBSERVAT"] == 'Whipple Observatory':
     obs = "MObs"
 
-#  if "USERID" in hdr.keys() and hdr["USERID"] == 'PatBoyce':
-#    obs = "Boyce"
-
-  if obs == "Boyce":
-    boyce_val = get_val(boyce, ks)
-    if (boyce_val != ""):
-      return(boyce_val)
   if obs == "MObs":
     mobs_val = get_val(mobs, ks)
     if (mobs_val != ""):

--- a/exotic/utils.py
+++ b/exotic/utils.py
@@ -584,8 +584,9 @@ def find(hdr, ks, obs=None):
     ks : list[str]
         a list of known values that astronomers use for a piece of information.
     obs : string
-        A specific observatory. Should be one of 'Boyce' or 'MObs' (no quotes).
-        Other values are ignored.
+        A specific observatory. 'MObs' selects the MicroObservatory site
+        constants; it is also set automatically when the header's OBSERVAT is
+        'Whipple Observatory'. Other values are ignored.
 
     Returns
     -------
@@ -593,8 +594,7 @@ def find(hdr, ks, obs=None):
         Most often returns a string but can return anything. Designed to return
         the latitude or longitude of an observation as a string.
     """
-    # Special stuff for MObs and Boyce-Astro Observatories
-    boyce = {"LATITUDE": "+32.6135", "LONGITUD": "-116.3334", "HEIGHT": 1405}
+    # Special stuff for MicroObservatory (MObs)
     # MicroObservatory telescopes sit at the Whipple Observatory base camp
     # (Amado, AZ), not on the Mount Hopkins summit (2606 m). See PR #1382.
     mobs = {"LATITUDE": "+31.675467", "LONGITUD": "-110.951376", "HEIGHT": 1268}
@@ -602,13 +602,6 @@ def find(hdr, ks, obs=None):
     if "OBSERVAT" in hdr.keys() and hdr["OBSERVAT"] == 'Whipple Observatory':
         obs = "MObs"
 
-    #  if "USERID" in hdr.keys() and hdr["USERID"] == 'PatBoyce':
-    #    obs = "Boyce"
-
-    if obs == "Boyce":
-        boyce_val = get_val(boyce, ks)
-        if boyce_val:
-            return boyce_val
     if obs == "MObs":
         mobs_val = get_val(mobs, ks)
         if mobs_val:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -644,23 +644,6 @@ class TestFind:
 
         assert result == whipple_observatory_height
 
-    def test_boyce_observatory(self):
-        """This does not appear to used in the implementation code"""
-
-        hdr = {"OBSERVAT": "NOT Whipple Observatory",
-               "LONG": "-123.45",
-               "LAT": "+34.56"}
-
-        search_keys = ['LONGITUD', 'LONG', 'LONGITUDE', 'SITELONG']
-        result = find(hdr, search_keys, obs="Boyce")
-
-        assert result == "-116.3334"  # this value is hard coded in the function
-
-        search_keys = ['LATITUDE', 'LAT', 'SITELAT']
-        result = find(hdr, search_keys, obs="Boyce")
-
-        assert result == "+32.6135"  # this value is hard coded in the function
-
     def test_mobs_observatory(self):
         """This does not appear to used in the implementation code"""
 


### PR DESCRIPTION
Requested by @mfitzasp in Slack ("crusty old barnacle, excise that") after the #1410 thread; @rzellem was fine with keeping it "if still needed", and it is not.

**What it was.** Both copies of `find()` (`exotic/utils.py`, `exotic/api/colab.py`) carried a Boyce-Astro site block: hardcoded lat/long/height (and filter in colab.py), a commented-out `USERID == 'PatBoyce'` auto-detection, and an `obs == "Boyce"` branch. `git blame` puts all of it in 1a13d58 (2022-11-21, colab.py's first commit), with the detection already commented out there. So the branch only fires when a caller passes `obs="Boyce"` explicitly, and inside the repository nothing does except `test_boyce_observatory`, whose own docstring says "This does not appear to used in the implementation code."

**Change.** Remove the Boyce constants, the dead detection, and the branch from both copies; remove the test; update the `obs` docstring. Net -32 lines.

**Unchanged.** MObs handling is identical (constants when `obs="MObs"` or the header says `Whipple Observatory`). The `obs` parameter stays, so `make_inits_file()` callers and any notebook passing it are unaffected; an unrecognised value falls through to the header, which is what every value other than the two special ones always did.

**Tests.** `tests/test_utils.py`: 58 passed on the branch (59 before, minus the removed one). Quick behavioural check on `utils.find`: Whipple header -> `+31.675467`; generic header -> header value; `obs="Boyce"` -> header value.

Only remaining "Boyce" in the tree is Pat Boyce in the citation author lists, which is where it belongs.
