### PR TITLE
Resolve planet aliases (HAT-P-10 b -> WASP-11 b) through the archive's alias-lookup service

### DIFF
--- a/exotic/api/nea.py
+++ b/exotic/api/nea.py
@@ -64,6 +64,40 @@ def result_if_max_retry_count(retry_state):
     pass
 
 
+NEA_ALIAS_LOOKUP_URL = "https://exoplanetarchive.ipac.caltech.edu/cgi-bin/Lookup/nph-aliaslookup.py"
+NEA_ALIAS_LOOKUP_TIMEOUT_SECONDS = 30
+
+
+def resolve_planet_alias(name, timeout=NEA_ALIAS_LOOKUP_TIMEOUT_SECONDS, getter=None):
+    """Return the archive's default planet name for an alias, or None.
+
+    The Planetary Systems table only answers to each planet's default name, so
+    a target observed under another designation (HAT-P-10 b is filed as
+    WASP-11 b; TOI and TIC names for confirmed planets) is reported as missing.
+    The archive's alias-lookup service knows every designation. A planet-level
+    alias resolves to that planet; a star-level alias resolves only when the
+    system holds exactly one planet. Any service problem returns None so the
+    caller falls through to its existing not-found handling.
+    """
+    getter = getter or requests.get
+    try:
+        response = getter(NEA_ALIAS_LOOKUP_URL, params={"objname": name}, timeout=timeout)
+        response.raise_for_status()
+        data = response.json()
+        manifest = data.get("manifest", {})
+        if manifest.get("lookup_status") != "OK":
+            return None
+        resolved = manifest.get("resolved_name")
+        planets = data.get("system", {}).get("objects", {}).get("planet_set", {}).get("planets", {})
+        if resolved in planets:
+            return resolved
+        if len(planets) == 1:
+            return next(iter(planets))
+    except (requests.RequestException, ValueError, AttributeError, TypeError):
+        pass
+    return None
+
+
 def _strip_observation_phase_suffix(name):
     """Remove scheduler phase labels that are not part of a target name."""
     text = str(name or '').strip()
@@ -395,6 +429,12 @@ class NASAExoplanetArchive:
         extra = self._tap_query(uri_ipac_base, uri_ipac_query)
 
         if len(default) == 0:
+            alias = resolve_planet_alias(self.planet)
+            if alias and alias != self.planet:
+                print(f"The NASA Exoplanet Archive lists {self.planet} under the name {alias}. Using that.")
+                self.planet = alias
+                return self._new_scrape(filename=filename)
+
             candidate_reason = self._candidate_name_reason(self.planet)
             if candidate_reason:
                 print(f"Cannot find target ({self.planet}) in NASA Exoplanet Archive."

--- a/tests/test_nea_alias_lookup.py
+++ b/tests/test_nea_alias_lookup.py
@@ -1,0 +1,81 @@
+import requests
+
+from exotic.api.nea import NEA_ALIAS_LOOKUP_URL, resolve_planet_alias
+
+
+class DummyResponse:
+    def __init__(self, payload, status_ok=True):
+        self._payload = payload
+        self._status_ok = status_ok
+
+    def raise_for_status(self):
+        if not self._status_ok:
+            raise requests.exceptions.HTTPError('503')
+
+    def json(self):
+        return self._payload
+
+
+def alias_payload(requested, resolved, status, planets):
+    return {
+        'manifest': {
+            'requested_name': requested,
+            'resolved_name': resolved,
+            'lookup_status': status,
+        },
+        'system': {
+            'objects': {
+                'planet_set': {
+                    'item_count': len(planets),
+                    'planets': {name: {} for name in planets},
+                }
+            }
+        },
+    }
+
+
+def make_getter(payload, status_ok=True, calls=None):
+    def getter(url, params=None, timeout=None):
+        if calls is not None:
+            calls.append((url, params, timeout))
+        return DummyResponse(payload, status_ok=status_ok)
+    return getter
+
+
+def test_planet_alias_resolves_to_default_planet_name():
+    calls = []
+    payload = alias_payload('HAT-P-10 b', 'WASP-11 b', 'OK', ['WASP-11 b'])
+    assert resolve_planet_alias('HAT-P-10 b', getter=make_getter(payload, calls=calls)) == 'WASP-11 b'
+    assert calls[0][0] == NEA_ALIAS_LOOKUP_URL
+    assert calls[0][1] == {'objname': 'HAT-P-10 b'}
+
+
+def test_star_alias_resolves_when_system_has_one_planet():
+    payload = alias_payload('HAT-P-10', 'WASP-11', 'OK', ['WASP-11 b'])
+    assert resolve_planet_alias('HAT-P-10', getter=make_getter(payload)) == 'WASP-11 b'
+
+
+def test_star_alias_is_ambiguous_in_multi_planet_system():
+    payload = alias_payload('TRAPPIST-1', 'TRAPPIST-1', 'OK',
+                            ['TRAPPIST-1 b', 'TRAPPIST-1 c', 'TRAPPIST-1 d'])
+    assert resolve_planet_alias('TRAPPIST-1', getter=make_getter(payload)) is None
+
+
+def test_unknown_name_returns_none():
+    payload = alias_payload('Nonsense-99 b', None, 'System Not Found', [])
+    assert resolve_planet_alias('Nonsense-99 b', getter=make_getter(payload)) is None
+
+
+def test_service_failure_returns_none():
+    payload = alias_payload('HAT-P-10 b', 'WASP-11 b', 'OK', ['WASP-11 b'])
+    assert resolve_planet_alias('HAT-P-10 b', getter=make_getter(payload, status_ok=False)) is None
+
+    def broken_getter(url, params=None, timeout=None):
+        raise requests.exceptions.ConnectionError('offline')
+
+    assert resolve_planet_alias('HAT-P-10 b', getter=broken_getter) is None
+
+
+def test_malformed_payload_returns_none():
+    assert resolve_planet_alias('HAT-P-10 b', getter=make_getter({'manifest': 'not a dict'})) is None
+    assert resolve_planet_alias('HAT-P-10 b', getter=make_getter([])) is None


### PR DESCRIPTION
Prompted by Art's note in #exotic today: last night's MObs schedule listed **HAT-P-10 b**, which the archive files under its default name **WASP-11 b**, so EXOTIC reported the target as missing and every MObs user had to know to retype the name.

**Cause.** `planet_info()` matches `pl_name` in the Planetary Systems table (and the cached `pl_names.json` built from it), which holds only default names. Aliases are never consulted.

**Change.** When the table returns no rows, `nea.py` asks the archive's alias-lookup service (`nph-aliaslookup.py?objname=...`) once, via a new `resolve_planet_alias()`:
- a planet-level alias resolves to that planet (`HAT-P-10 b` -> `WASP-11 b`);
- a star-level alias resolves only when the system holds exactly one planet (`HAT-P-10` -> `WASP-11 b`; `TRAPPIST-1` -> None);
- unknown names, HTTP/connection errors and malformed payloads return None, and the existing candidate / not-found handling runs exactly as before.

On a hit it prints `The NASA Exoplanet Archive lists HAT-P-10 b under the name WASP-11 b. Using that.` and re-runs the lookup under the default name, so the output and AAVSO files carry the canonical name. A name that resolves to itself cannot loop.

**Side effect, deliberate.** Confirmed planets given by TOI/TIC designation now get their archive parameters (`TOI-4516.01` -> `WASP-11 b`, `TOI-1136.01` -> `TOI-1136 d`, resolved at planet level so multi-planet systems are not guessed). Unconfirmed candidates (`TOI-99999.01`) return None and are still treated as candidates. One extra HTTP call (about a second) only on the not-found path.

**Tests.** `tests/test_nea_alias_lookup.py`, seven cases with a stubbed getter, plus the existing nextastro fallback tests: 13 passed. Live check on this branch: `NASAExoplanetArchive(planet='HAT-P-10 b', non_interactive=True).planet_info()` succeeds as WASP-11 b; `Nonsense-99 b` still raises the same RuntimeError.
