### PR TITLE
Initialization-file pre-flight: exotic -pf inits.json

### DIFF
--- a/exotic/api/preflight.py
+++ b/exotic/api/preflight.py
@@ -1,0 +1,268 @@
+# ########################################################################### #
+#    Copyright (c) 2019-2020, California Institute of Technology.
+#    All rights reserved.  Based on Government Sponsored Research under
+#    contracts NNN12AA01C, NAS7-1407 and/or NAS7-03001.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions
+#    are met:
+#      1. Redistributions of source code must retain the above copyright
+#         notice, this list of conditions and the following disclaimer.
+#      2. Redistributions in binary form must reproduce the above copyright
+#         notice, this list of conditions and the following disclaimer in
+#         the documentation and/or other materials provided with the
+#         distribution.
+#      3. Neither the name of the California Institute of
+#         Technology (Caltech), its operating division the Jet Propulsion
+#         Laboratory (JPL), the National Aeronautics and Space
+#         Administration (NASA), nor the names of its contributors may be
+#         used to endorse or promote products derived from this software
+#         without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE CALIFORNIA
+#    INSTITUTE OF TECHNOLOGY BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+#    TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#    PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#    LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# ########################################################################### #
+#    EXOplanet Transit Interpretation Code (EXOTIC)
+#    # NOTE: See companion file version.py for version info.
+# ########################################################################### #
+"""Pre-flight checks for an initialization file, run before any photometry.
+
+Every check here is cheap (FITS headers, one image, one archive query, at most
+one plate solve) and targets a mistake that -ov otherwise lets through until an
+hour of reduction has been spent on it:
+
+  * planetary parameters copied from a template and never edited
+    (archive agreement: period, Rp/Rs, a/Rs, inclination)
+  * an ephemeris whose transit does not fall in the observing window
+  * a target pixel that is not on the target (checked against a WCS)
+  * comparison stars off the frame, saturated, or within noise of blank sky
+
+The functions in this module take plain values (dicts, arrays, a WCS) so they
+can be tested without frames or network; ``exotic.py`` wires them to the
+initialization file, the NASA Exoplanet Archive and the plate solvers.
+"""
+import numpy as np
+
+PASS = 'pass'
+FAIL = 'fail'
+LOOK = 'look'
+SKIP = 'skip'
+
+_STATUS_MARK = {PASS: 'ok  ', FAIL: 'FAIL', LOOK: 'look', SKIP: '    '}
+
+# Relative tolerances for archive agreement. The period is held tight because
+# it is the parameter a template copy gets wrong by a lot (a wrong period puts
+# the predicted transit anywhere), while the geometry may legitimately differ
+# between the archive default row and a newer literature source.
+ARCHIVE_TOLERANCES = {
+    'pPer': ('Orbital Period (days)', 1e-4),
+    'rprs': ('Ratio of Planet to Stellar Radius (Rp/Rs)', 0.15),
+    'aRs': ('Ratio of Distance to Stellar Radius (a/Rs)', 0.15),
+    'inc': ('Orbital Inclination (deg)', 0.02),
+}
+
+TARGET_PIXEL_TOLERANCE_PX = 8.0
+COMPARISON_MIN_SNR = 5.0
+COMPARISON_BRIGHTNESS_RATIO_RANGE = (0.1, 20.0)
+PEAK_SEARCH_HALF_WIDTH_PX = 5
+
+
+class PreflightReport:
+    """Ordered list of (status, label, detail) with a hard-failure verdict."""
+
+    def __init__(self):
+        self.checks = []
+
+    def add(self, status, label, detail=''):
+        self.checks.append((status, label, detail))
+        return status
+
+    def passed(self, ok, label, detail=''):
+        return self.add(PASS if ok else FAIL, label, detail)
+
+    def look(self, ok, label, detail=''):
+        """Report without failing: a judgment call, not a rule."""
+        return self.add(PASS if ok else LOOK, label, detail)
+
+    def skip(self, label, detail=''):
+        return self.add(SKIP, label, detail)
+
+    @property
+    def failures(self):
+        return [label for status, label, _ in self.checks if status == FAIL]
+
+    @property
+    def ok(self):
+        return not self.failures
+
+    def lines(self):
+        for status, label, detail in self.checks:
+            yield f"  [{_STATUS_MARK[status]}] {label}" + (f"  {detail}" if detail else '')
+
+    def summary(self):
+        if self.failures:
+            return f"{len(self.failures)} pre-flight check(s) failed. Do not reduce with this file yet."
+        return "All pre-flight checks passed."
+
+
+def _finite(value):
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        return None
+    return value if np.isfinite(value) else None
+
+
+def compare_archive_parameters(planet_dict, archive_dict, report, tolerances=ARCHIVE_TOLERANCES):
+    """Check the initialization file's planetary parameters against the archive."""
+    for key, (label, tolerance) in tolerances.items():
+        mine = _finite(planet_dict.get(key))
+        theirs = _finite(archive_dict.get(key)) if archive_dict else None
+        if theirs is None or theirs == 0:
+            report.skip(label, 'no archive value to compare against')
+            continue
+        if mine is None:
+            report.passed(False, label, f"missing in the initialization file (archive {theirs})")
+            continue
+        relative = abs(mine - theirs) / abs(theirs)
+        report.passed(relative <= tolerance, label,
+                      f"inits {mine}  archive {theirs}  ({relative * 100:.2f}% off, tolerance {tolerance * 100:g}%)")
+    return report
+
+
+def predicted_mid_transit(jd_start, jd_end, mid_transit, period):
+    """Epoch of the published ephemeris nearest the middle of the observing window."""
+    cycle = np.round(((jd_start + jd_end) / 2.0 - mid_transit) / period)
+    return float(mid_transit + cycle * period), int(cycle)
+
+
+def check_transit_window(jd_start, jd_end, mid_transit, period, duration_days, report):
+    """Fail if no part of the predicted transit falls in the observing window.
+
+    A partial transit is reported for the observer's judgment but is not a
+    failure: the pipeline fits partials. The failure this exists for is the
+    template-copy ephemeris whose transit is nowhere near the night.
+    """
+    jd_start, jd_end = _finite(jd_start), _finite(jd_end)
+    mid_transit, period = _finite(mid_transit), _finite(period)
+    if jd_start is None or jd_end is None or jd_end < jd_start:
+        report.passed(False, 'observing window from the FITS headers', 'could not read start and end times')
+        return report
+    if mid_transit is None or period is None or period <= 0:
+        report.passed(False, 'ephemeris usable', f"Tmid {mid_transit} period {period}")
+        return report
+
+    tmid, cycle = predicted_mid_transit(jd_start, jd_end, mid_transit, period)
+    hours = (jd_end - jd_start) * 24.0
+    offset_hours = (tmid - jd_start) * 24.0
+    report.add(SKIP, 'observing window', f"{jd_start:.5f} -> {jd_end:.5f}  ({hours:.2f} h, epoch {cycle})")
+
+    duration = _finite(duration_days)
+    if duration is None or duration <= 0:
+        report.passed(jd_start <= tmid <= jd_end, 'predicted mid-transit inside the window',
+                      f"Tmid {tmid:.5f} ({offset_hours:+.2f} h from start); no duration available")
+        return report
+
+    ingress, egress = tmid - duration / 2.0, tmid + duration / 2.0
+    overlaps = egress >= jd_start and ingress <= jd_end
+    report.passed(overlaps, 'predicted transit overlaps the window',
+                  f"Tmid {tmid:.5f} ({offset_hours:+.2f} h from start), duration {duration * 24:.2f} h")
+    if overlaps:
+        report.look(ingress >= jd_start and egress <= jd_end, 'full transit inside the window',
+                    f"ingress {(ingress - jd_start) * 24:+.2f} h  egress {(egress - jd_start) * 24:+.2f} h from start"
+                    + ('' if ingress >= jd_start and egress <= jd_end else '  (partial transit)'))
+    return report
+
+
+def check_target_pixel(wcs, ra_deg, dec_deg, target_xy, report, tolerance_px=TARGET_PIXEL_TOLERANCE_PX,
+                       frame_label='first frame'):
+    """Project the target's RA/Dec through a WCS and compare with the seed pixel."""
+    ra_deg, dec_deg = _finite(ra_deg), _finite(dec_deg)
+    if ra_deg is None or dec_deg is None:
+        report.skip('target pixel on the target', 'no target RA/Dec available')
+        return report
+    try:
+        expected = np.asarray(wcs.all_world2pix(ra_deg, dec_deg, 0), dtype=float)
+        seed = np.asarray(target_xy, dtype=float)
+        separation = float(np.hypot(*(expected - seed)))
+    except Exception as exc:
+        report.skip('target pixel on the target', f"WCS projection failed: {exc}")
+        return report
+    report.passed(separation <= tolerance_px, f"target pixel on the target ({frame_label})",
+                  f"WCS puts the target at ({expected[0]:.1f}, {expected[1]:.1f}); "
+                  f"inits pixel ({seed[0]:.0f}, {seed[1]:.0f}) is {separation:.1f} px away (tolerance {tolerance_px:g})")
+    return report
+
+
+def peak_above_background(image, x, y, background, half_width=PEAK_SEARCH_HALF_WIDTH_PX):
+    """Brightest pixel in a small box around (x, y), minus the background; None if off the frame."""
+    height, width = image.shape[:2]
+    if not (0 <= x < width and 0 <= y < height):
+        return None
+    x0, x1 = max(0, int(x) - half_width), int(x) + half_width + 1
+    y0, y1 = max(0, int(y) - half_width), int(y) + half_width + 1
+    return float(np.nanmax(image[y0:y1, x0:x1])) - background
+
+
+def check_comparison_stars(image, target_xy, comparison_xy, saturation_value, report,
+                           overexposure_fraction=0.9):
+    """Comparison stars must be on the frame and below the overexposure threshold.
+
+    Brightness relative to the target is a judgment call reported without failing:
+    one frame is a small sample, and on a clouded night the first frame can be the
+    worst one. Off-frame and overexposed are rules; the pipeline would reject them
+    later anyway, and this says so before the photometry is run.
+    """
+    image = np.asarray(image, dtype=float)
+    background = float(np.nanmedian(image))
+    quiet = image[image < np.nanpercentile(image, 95)]
+    noise = float(np.nanstd(quiet)) if quiet.size else float('nan')
+    target_peak = peak_above_background(image, target_xy[0], target_xy[1], background)
+    threshold = saturation_value * overexposure_fraction if _finite(saturation_value) else None
+
+    if target_peak is None:
+        report.passed(False, 'target pixel inside the frame', f"({target_xy[0]}, {target_xy[1]}) is off the frame")
+    else:
+        report.add(SKIP, 'first-frame photometry context',
+                   f"background {background:.0f}, noise {noise:.0f}, target peak {target_peak:+.0f} ADU above background")
+        if threshold is not None:
+            report.passed(target_peak + background < threshold, 'target unsaturated',
+                          f"peak {target_peak + background:.0f} vs threshold {threshold:.0f}")
+
+    if not comparison_xy:
+        report.skip('comparison stars', 'none given in the initialization file')
+        return report
+
+    for comp in comparison_xy:
+        try:
+            cx, cy = float(comp[0]), float(comp[1])
+        except (TypeError, ValueError, IndexError):
+            report.passed(False, f"comp {comp!r}", 'not an [x, y] pair')
+            continue
+        label = f"comp ({cx:.0f}, {cy:.0f})"
+        peak = peak_above_background(image, cx, cy, background)
+        if peak is None:
+            report.passed(False, f"{label} inside the frame", 'outside the frame')
+            continue
+        if threshold is not None:
+            report.passed(peak + background < threshold, f"{label} unsaturated",
+                          f"peak {peak + background:.0f} vs threshold {threshold:.0f}")
+        if target_peak and target_peak > 0:
+            ratio = peak / target_peak
+            low, high = COMPARISON_BRIGHTNESS_RATIO_RANGE
+            report.look(peak > COMPARISON_MIN_SNR * noise and low <= ratio <= high, f"{label} brightness",
+                        f"{peak:+.0f} ADU above background, {ratio:.1f}x the target")
+        else:
+            report.look(peak > COMPARISON_MIN_SNR * noise, f"{label} brightness",
+                        f"{peak:+.0f} ADU above background")
+    return report

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -126,14 +126,18 @@ try:  # output files
         CALIBRATION_MASTER_FILENAMES,
         Inputs,
         NEXTASTRO_GAIA_DISTPM_ENDPOINT,
+        check_imaging_files,
         comparison_star_coords,
+        target_star_coords,
     )
 except ImportError:  # package import
     from .inputs import (
         CALIBRATION_MASTER_FILENAMES,
         Inputs,
         NEXTASTRO_GAIA_DISTPM_ENDPOINT,
+        check_imaging_files,
         comparison_star_coords,
+        target_star_coords,
     )
 try:  # ld
     from .api.ld import LimbDarkening, ld_re_punct_p
@@ -143,6 +147,10 @@ try:  # plate solution
     from .api.plate_solution import NextAstroPlateSolution, NovaSourceListPlateSolution, PlateSolution
 except ImportError:  # package import
     from api.plate_solution import NextAstroPlateSolution, NovaSourceListPlateSolution, PlateSolution
+try:  # inits pre-flight
+    from .api import preflight as inits_preflight
+except ImportError:  # package import
+    from api import preflight as inits_preflight
 try:
     from .api.ultranest_utils import (
         get_mpi_status,
@@ -16322,6 +16330,179 @@ def get_wcs(file, directory="", use_nextastro_astrometry=False, ra=None, dec=Non
         return False
     return PlateSolution.fail(nextastro_solver.last_error_type or 'plate solution lookup',
                               service_name=f'NextAstro ({nextastro_solver.api_url})')
+
+
+PREFLIGHT_LEADING_FRAMES_TO_SOLVE = 3
+
+
+def _preflight_wcs_for_frame(file_name, save_directory, plate_opt, use_nextastro_astrometry, ra, dec, pixel_scale):
+    """Return (WCS, how) for one frame, or (None, why) without raising.
+
+    Header WCS is used as-is. Otherwise the initialization file's plate-solution
+    answer decides what may leave the machine: 'y' runs the pipeline's own solver
+    order (nova.astrometry.net first, NextAstro as the fallback, or the reverse
+    under --use-nextastro-astrometry); 'n' sends only a source list to NextAstro,
+    because the user declined to upload an image.
+    """
+    try:
+        header_wcs = search_wcs(file_name)
+        if header_wcs.is_celestial:
+            return header_wcs, 'header WCS'
+    except Exception:
+        pass
+
+    Path(Path(save_directory) / "working_artifacts").mkdir(parents=True, exist_ok=True)
+    if plate_opt == 'y':
+        wcs_file = get_wcs(file_name, save_directory, use_nextastro_astrometry=use_nextastro_astrometry,
+                           ra=ra, dec=dec, pixel_scale=pixel_scale)
+        how = 'plate solution'
+    else:
+        log_info("Plate Solution? is 'n' in the initialization file, so no image is uploaded: "
+                 "sending a source list to the NextAstro astrometry server only.")
+        wcs_file = NextAstroPlateSolution(file=file_name, directory=save_directory, ra=ra, dec=dec,
+                                          pixel_scale=pixel_scale, suppress_fail_warning=True,
+                                          message_logger=log.debug).plate_solution()
+        how = 'NextAstro source-list solution'
+    if not wcs_file:
+        return None, 'did not solve'
+    try:
+        return search_wcs(wcs_file), how
+    except Exception as exc:
+        return None, f'solution unreadable ({exc})'
+
+
+def run_inits_preflight(init_path, use_nextastro_astrometry=False):
+    """Check an initialization file against the archive, the headers and one frame.
+
+    Returns 0 when nothing hard failed, 1 otherwise, so a scripted run can gate on
+    it: ``exotic -pf inits.json && exotic -red inits.json -ov``.
+    """
+    report = inits_preflight.PreflightReport()
+    planet_dict = {key: None for key in ('ra', 'dec', 'pName', 'sName', 'pPer', 'pPerUnc', 'midT', 'midTUnc',
+                                         'rprs', 'rprsUnc', 'aRs', 'aRsUnc', 'inc', 'incUnc', 'omega', 'ecc',
+                                         'teff', 'teffUncPos', 'teffUncNeg', 'met', 'metUncPos', 'metUncNeg',
+                                         'logg', 'loggUncPos', 'loggUncNeg', 'dist', 'pm_ra', 'pm_dec')}
+    inputs_obj = Inputs(init_opt='y')
+    init_path, planet_dict = inputs_obj.search_init(init_path, planet_dict)
+    info = inputs_obj.info_dict
+    planet_name = planet_dict.get('pName')
+
+    log_info("\n**************************************")
+    log_info("Initialization File Pre-flight")
+    log_info("**************************************")
+    log_info(f"{init_path}  ->  {planet_name}")
+
+    # --- frames and observing window ---------------------------------------
+    input_files = check_imaging_files(info.get('images'), 'Imaging', exclude_calibration_masters=True)
+    timed_files = []
+    for file_name in input_files:
+        try:
+            jd = img_time_jd(get_first_image_header(file_name))
+        except Exception:
+            jd = np.nan
+        if np.isfinite(jd):
+            timed_files.append((float(jd), file_name))
+    timed_files.sort()
+    untimed = len(input_files) - len(timed_files)
+    report.passed(bool(timed_files), 'frames with a readable observation time',
+                  f"{len(timed_files)} of {len(input_files)}" + (f" ({untimed} without a usable time header)" if untimed else ''))
+
+    # --- archive ---------------------------------------------------------------
+    archive = None
+    try:
+        _, candidate, archive_parameters = NASAExoplanetArchive(planet=planet_name, non_interactive=True).planet_info()
+        if candidate or not isinstance(archive_parameters, dict):
+            report.skip('NASA Exoplanet Archive comparison', f"{planet_name} is a candidate; nothing to compare against")
+        else:
+            archive = archive_parameters
+            report.passed(True, 'planet found in the NASA Exoplanet Archive', str(archive.get('pName', planet_name)))
+    except Exception as exc:
+        report.passed(False, 'planet found in the NASA Exoplanet Archive', f"{planet_name}: {type(exc).__name__}: {exc}")
+    if archive is not None:
+        inits_preflight.compare_archive_parameters(planet_dict, archive, report)
+
+    # --- timing ----------------------------------------------------------------
+    def value_or_archive(key):
+        value = inits_preflight._finite(planet_dict.get(key))
+        if value is None and archive is not None:
+            value = inits_preflight._finite(archive.get(key))
+        return value
+
+    duration_days = estimate_transit_duration_from_prior_geometry({
+        'per': value_or_archive('pPer'), 'rprs': value_or_archive('rprs'), 'ars': value_or_archive('aRs'),
+        'inc': value_or_archive('inc'), 'ecc': value_or_archive('ecc') or 0.0, 'omega': value_or_archive('omega') or 0.0,
+    })
+    if timed_files:
+        inits_preflight.check_transit_window(timed_files[0][0], timed_files[-1][0], value_or_archive('midT'),
+                                             value_or_archive('pPer'), duration_days, report)
+
+    # --- pointing: is the seed pixel on the target? ----------------------------
+    target_xy = target_star_coords(info.get('tar_coords'), planet_name)
+    ra_deg = inits_preflight._finite(archive.get('ra')) if archive is not None else None
+    dec_deg = inits_preflight._finite(archive.get('dec')) if archive is not None else None
+    if ra_deg is None or dec_deg is None:
+        try:
+            ra_deg, dec_deg = radec_hours_to_degree(planet_dict.get('ra'), planet_dict.get('dec'),
+                                                    non_interactive_run=True, target_name=planet_name)
+        except Exception as exc:
+            report.skip('target RA/Dec', f"unusable in the initialization file and no archive value: {exc}")
+            ra_deg = dec_deg = None
+
+    if timed_files and ra_deg is not None:
+        first_header = get_first_image_header(timed_files[0][1])
+        pixel_scale = info.get('pixel_scale') or first_header.get('IM_SCALE') or first_header.get('PIXSCALE')
+        save_directory = info.get('save')
+        if not save_directory or not Path(save_directory).is_dir():
+            save_directory = tempfile.mkdtemp(prefix='exotic-preflight-')
+        plate_opt = 'y' if coerce_boolean_config_value(info.get('plate_opt')) else 'n'
+        solved = False
+        for index, (_, file_name) in enumerate(timed_files[:PREFLIGHT_LEADING_FRAMES_TO_SOLVE]):
+            wcs, how = _preflight_wcs_for_frame(file_name, save_directory, plate_opt, use_nextastro_astrometry,
+                                                ra_deg, dec_deg, pixel_scale)
+            if wcs is None:
+                report.skip(f"frame {index + 1} ({Path(file_name).name})", how)
+                continue
+            inits_preflight.check_target_pixel(wcs, ra_deg, dec_deg, target_xy, report,
+                                               frame_label=f"frame {index + 1}, {how}")
+            report.look(index == 0, 'seed frame is the first frame',
+                        'EXOTIC seeds from the first frame; the first frame did not solve, so this was checked '
+                        f'on frame {index + 1}' if index else 'first frame solved')
+            solved = True
+            break
+        if not solved:
+            report.skip('target pixel on the target',
+                        f"none of the first {min(PREFLIGHT_LEADING_FRAMES_TO_SOLVE, len(timed_files))} frames "
+                        "gave a WCS; not checked")
+
+    # --- comparison stars on the first frame ----------------------------------
+    if timed_files:
+        first_file = timed_files[0][1]
+        first_header = get_first_image_header(first_file)
+        extension = 0
+        while fits.getheader(first_file, ext=extension).get('NAXIS', 0) == 0:
+            extension += 1
+        image = np.asarray(fits.getdata(first_file, ext=extension), dtype=float)
+        if image.ndim > 2:
+            image = image.squeeze()
+        saturation = saturation_value_from_header(first_header)
+        if saturation is None:
+            saturation = parse_saturation_value(info.get('saturation_value'))
+        fraction = info.get('overexposure_threshold_fraction')
+        try:
+            fraction = float(fraction) if fraction not in (None, '') else OVEREXPOSURE_THRESHOLD_FRACTION_DEFAULT
+        except (TypeError, ValueError):
+            fraction = OVEREXPOSURE_THRESHOLD_FRACTION_DEFAULT
+        comps = info.get('comp_stars')
+        comps = [c for c in comps if isinstance(c, (list, tuple)) and len(c) == 2] if isinstance(comps, list) else []
+        inits_preflight.check_comparison_stars(image, target_xy, comps, saturation, report,
+                                               overexposure_fraction=fraction)
+
+    log_info("")
+    for line in report.lines():
+        log_info(line, error=line.lstrip().startswith('[FAIL]'), warn=line.lstrip().startswith('[look]'))
+    log_info("")
+    log_info(report.summary(), error=not report.ok)
+    return 0 if report.ok else 1
 
 
 # Getting the right ascension and declination for every pixel in imaging file if there is a plate solution
@@ -34631,6 +34812,13 @@ def parse_args():
                              "least-squares transit inference. FITS inputs use aperture-only photometry. "
                              "Results are preliminary. "
                              "An initialization file (e.g., inits.json) is optional to use with this command.")
+    parser.add_argument('-pf', '--preflight',
+                        nargs='?', default=None, type=str, const='',
+                        help="Checks an initialization file before any reduction: planetary parameters against "
+                             "the NASA Exoplanet Archive, the predicted transit against the observing window in "
+                             "the FITS headers, the target pixel against a plate solution, and comparison stars "
+                             "for being on the frame and unsaturated. Exits 1 on a hard failure, so scripted runs "
+                             "can gate on it: exotic -pf inits.json && exotic -red inits.json -ov")
     parser.add_argument('-ov', '--override',
                         action='store_true',
                         help="Adopts all JSON planetary parameters, which will override the NASA Exoplanet Archive. "
@@ -34679,6 +34867,10 @@ def _main_impl():
     if args.multiprocess_lightcurve_fits is not None and args.multiprocess_lightcurve_fits < 1:
         raise ValueError("--multiprocess-lightcurve-fits requires an integer greater than 0.")
     configure_windows_multiprocessing_main_spec()
+    preflight_argument = getattr(args, 'preflight', None)
+    if isinstance(preflight_argument, str):
+        return run_inits_preflight(preflight_argument,
+                                   use_nextastro_astrometry=getattr(args, 'use_nextastro_astrometry', False))
     quick_look_argument = getattr(args, 'quick_look', None)
     explicit_quick_look_mode = isinstance(quick_look_argument, str)
     configured_quick_look_init = next(

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -16335,14 +16335,12 @@ def get_wcs(file, directory="", use_nextastro_astrometry=False, ra=None, dec=Non
 PREFLIGHT_LEADING_FRAMES_TO_SOLVE = 3
 
 
-def _preflight_wcs_for_frame(file_name, save_directory, plate_opt, use_nextastro_astrometry, ra, dec, pixel_scale):
+def _preflight_wcs_for_frame(file_name, save_directory, use_nextastro_astrometry, ra, dec, pixel_scale):
     """Return (WCS, how) for one frame, or (None, why) without raising.
 
-    Header WCS is used as-is. Otherwise the initialization file's plate-solution
-    answer decides what may leave the machine: 'y' runs the pipeline's own solver
-    order (nova.astrometry.net first, NextAstro as the fallback, or the reverse
-    under --use-nextastro-astrometry); 'n' sends only a source list to NextAstro,
-    because the user declined to upload an image.
+    Header WCS is used as-is. Otherwise the pipeline's own solver order runs
+    (nova.astrometry.net from a source list first, NextAstro as the fallback, or
+    the reverse under --use-nextastro-astrometry). Neither uploads the image.
     """
     try:
         header_wcs = search_wcs(file_name)
@@ -16352,17 +16350,9 @@ def _preflight_wcs_for_frame(file_name, save_directory, plate_opt, use_nextastro
         pass
 
     Path(Path(save_directory) / "working_artifacts").mkdir(parents=True, exist_ok=True)
-    if plate_opt == 'y':
-        wcs_file = get_wcs(file_name, save_directory, use_nextastro_astrometry=use_nextastro_astrometry,
-                           ra=ra, dec=dec, pixel_scale=pixel_scale)
-        how = 'plate solution'
-    else:
-        log_info("Plate Solution? is 'n' in the initialization file, so no image is uploaded: "
-                 "sending a source list to the NextAstro astrometry server only.")
-        wcs_file = NextAstroPlateSolution(file=file_name, directory=save_directory, ra=ra, dec=dec,
-                                          pixel_scale=pixel_scale, suppress_fail_warning=True,
-                                          message_logger=log.debug).plate_solution()
-        how = 'NextAstro source-list solution'
+    wcs_file = get_wcs(file_name, save_directory, use_nextastro_astrometry=use_nextastro_astrometry,
+                       ra=ra, dec=dec, pixel_scale=pixel_scale)
+    how = 'plate solution'
     if not wcs_file:
         return None, 'did not solve'
     try:
@@ -16454,10 +16444,9 @@ def run_inits_preflight(init_path, use_nextastro_astrometry=False):
         save_directory = info.get('save')
         if not save_directory or not Path(save_directory).is_dir():
             save_directory = tempfile.mkdtemp(prefix='exotic-preflight-')
-        plate_opt = 'y' if coerce_boolean_config_value(info.get('plate_opt')) else 'n'
         solved = False
         for index, (_, file_name) in enumerate(timed_files[:PREFLIGHT_LEADING_FRAMES_TO_SOLVE]):
-            wcs, how = _preflight_wcs_for_frame(file_name, save_directory, plate_opt, use_nextastro_astrometry,
+            wcs, how = _preflight_wcs_for_frame(file_name, save_directory, use_nextastro_astrometry,
                                                 ra_deg, dec_deg, pixel_scale)
             if wcs is None:
                 report.skip(f"frame {index + 1} ({Path(file_name).name})", how)

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,324 @@
+"""Initialization-file pre-flight (``exotic -pf inits.json``).
+
+Each check targets a mistake that -ov otherwise lets through until the
+reduction has already been run: a template copy's ephemeris, a transit
+outside the window, a seed pixel off the target, comparison stars off the
+frame or saturated.
+"""
+import json
+from pathlib import Path
+
+import numpy as np
+from astropy.io import fits
+from astropy.wcs import WCS
+import pytest
+
+from exotic.api import preflight
+from exotic.api.preflight import (
+    FAIL, LOOK, PASS, SKIP,
+    PreflightReport,
+    check_comparison_stars,
+    check_target_pixel,
+    check_transit_window,
+    compare_archive_parameters,
+    predicted_mid_transit,
+)
+
+WASP11 = {'pName': 'WASP-11 b', 'pPer': 3.72247975, 'midT': 2456933.615316, 'rprs': 0.1413, 'aRs': 12.3,
+          'inc': 89.1, 'ecc': 0.0, 'omega': 0.0, 'ra': 47.368958, 'dec': 30.673389}
+HATP32_SAMPLE_PERIOD = 2.1500082  # the shipped sample's period, the classic template-copy leftover
+
+
+def statuses(report):
+    return {label: status for status, label, _ in report.checks}
+
+
+# --- archive agreement -----------------------------------------------------
+
+def test_archive_agreement_passes_when_values_match():
+    report = compare_archive_parameters(dict(WASP11), dict(WASP11), PreflightReport())
+    assert report.ok
+    assert set(statuses(report).values()) == {PASS}
+
+
+def test_template_period_fails_loudly():
+    mine = dict(WASP11, pPer=HATP32_SAMPLE_PERIOD)
+    report = compare_archive_parameters(mine, dict(WASP11), PreflightReport())
+    assert report.failures == ['Orbital Period (days)']
+
+
+def test_geometry_tolerance_is_looser_than_period():
+    mine = dict(WASP11, rprs=WASP11['rprs'] * 1.10, aRs=WASP11['aRs'] * 0.90, inc=WASP11['inc'] * 1.01)
+    assert compare_archive_parameters(mine, dict(WASP11), PreflightReport()).ok
+    mine = dict(WASP11, pPer=WASP11['pPer'] * 1.001)
+    assert not compare_archive_parameters(mine, dict(WASP11), PreflightReport()).ok
+
+
+def test_missing_archive_value_is_skipped_not_failed():
+    archive = dict(WASP11, aRs=np.nan)
+    report = compare_archive_parameters(dict(WASP11), archive, PreflightReport())
+    assert report.ok
+    assert statuses(report)['Ratio of Distance to Stellar Radius (a/Rs)'] == SKIP
+
+
+def test_missing_inits_value_fails():
+    mine = dict(WASP11, inc=None)
+    report = compare_archive_parameters(mine, dict(WASP11), PreflightReport())
+    assert report.failures == ['Orbital Inclination (deg)']
+
+
+# --- timing ------------------------------------------------------------------
+
+# MicroObservatory WASP-11 b night of 2026-09-05: 07:42-12:21 UT, Tmid 09:59:56 UT.
+NIGHT_START, NIGHT_END = 2461288.8211, 2461289.0146
+DURATION_DAYS = 2.6 / 24.0
+
+
+def test_predicted_epoch_is_the_one_nearest_the_window():
+    tmid, cycle = predicted_mid_transit(NIGHT_START, NIGHT_END, WASP11['midT'], WASP11['pPer'])
+    assert cycle == 1170
+    assert abs(tmid - 2461288.9166) < 1e-3
+
+
+def test_full_transit_inside_window_passes_cleanly():
+    report = check_transit_window(NIGHT_START, NIGHT_END, WASP11['midT'], WASP11['pPer'], DURATION_DAYS,
+                                  PreflightReport())
+    assert report.ok
+    assert statuses(report)['full transit inside the window'] == PASS
+
+
+def test_partial_transit_is_flagged_not_failed():
+    # window ends 20 minutes after mid-transit: egress is cut
+    report = check_transit_window(NIGHT_START, 2461288.9166 + 20 / 1440, WASP11['midT'], WASP11['pPer'],
+                                  DURATION_DAYS, PreflightReport())
+    assert report.ok
+    assert statuses(report)['full transit inside the window'] == LOOK
+
+
+def test_template_period_puts_transit_outside_window():
+    report = check_transit_window(NIGHT_START, NIGHT_END, WASP11['midT'], HATP32_SAMPLE_PERIOD, DURATION_DAYS,
+                                  PreflightReport())
+    assert report.failures == ['predicted transit overlaps the window']
+
+
+def test_no_duration_falls_back_to_mid_transit_in_window():
+    report = check_transit_window(NIGHT_START, NIGHT_END, WASP11['midT'], WASP11['pPer'], np.nan,
+                                  PreflightReport())
+    assert report.ok
+    assert 'predicted mid-transit inside the window' in statuses(report)
+
+
+def test_unreadable_window_fails():
+    report = check_transit_window(np.nan, NIGHT_END, WASP11['midT'], WASP11['pPer'], DURATION_DAYS,
+                                  PreflightReport())
+    assert report.failures == ['observing window from the FITS headers']
+
+
+# --- pointing --------------------------------------------------------------------
+
+def tan_wcs(crpix=(208.0, 342.0), scale_arcsec=5.0, ra=WASP11['ra'], dec=WASP11['dec']):
+    wcs = WCS(naxis=2)
+    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+    wcs.wcs.crval = [ra, dec]
+    wcs.wcs.crpix = [crpix[0] + 1, crpix[1] + 1]  # FITS 1-based
+    wcs.wcs.cdelt = [-scale_arcsec / 3600.0, scale_arcsec / 3600.0]
+    return wcs
+
+
+def test_seed_pixel_on_target_passes():
+    report = check_target_pixel(tan_wcs(), WASP11['ra'], WASP11['dec'], [208, 342], PreflightReport())
+    assert report.ok
+
+
+def test_seed_pixel_off_target_fails_with_distance():
+    report = check_target_pixel(tan_wcs(), WASP11['ra'], WASP11['dec'], [215, 300], PreflightReport())
+    assert len(report.failures) == 1
+    _, _, detail = report.checks[0]
+    assert '42.6 px' in detail
+
+
+def test_seed_pixel_within_tolerance_passes():
+    report = check_target_pixel(tan_wcs(), WASP11['ra'], WASP11['dec'], [212, 345], PreflightReport())
+    assert report.ok
+
+
+def test_missing_coordinates_skip_the_pointing_check():
+    report = check_target_pixel(tan_wcs(), None, WASP11['dec'], [208, 342], PreflightReport())
+    assert report.ok
+    assert statuses(report)['target pixel on the target'] == SKIP
+
+
+# --- comparison stars ------------------------------------------------------------
+
+def frame(shape=(500, 650), background=420.0, noise=8.0, stars=(), seed=1):
+    rng = np.random.default_rng(seed)
+    image = background + noise * rng.standard_normal(shape)
+    for x, y, peak in stars:
+        image[y, x] = background + peak
+    return image
+
+
+TARGET = (208, 342, 900.0)
+SATURATION = 4096.0
+
+
+def test_good_comparisons_pass():
+    image = frame(stars=[TARGET, (388, 471, 1500.0), (589, 211, 400.0)])
+    report = check_comparison_stars(image, TARGET[:2], [[388, 471], [589, 211]], SATURATION, PreflightReport())
+    assert report.ok
+    assert LOOK not in statuses(report).values()
+
+
+def test_comparison_off_frame_fails():
+    image = frame(stars=[TARGET])
+    report = check_comparison_stars(image, TARGET[:2], [[700, 100]], SATURATION, PreflightReport())
+    assert report.failures == ['comp (700, 100) inside the frame']
+
+
+def test_saturated_comparison_fails_at_overexposure_fraction():
+    image = frame(stars=[TARGET, (388, 471, SATURATION * 0.92 - 420.0)])
+    report = check_comparison_stars(image, TARGET[:2], [[388, 471]], SATURATION, PreflightReport(),
+                                    overexposure_fraction=0.9)
+    assert report.failures == ['comp (388, 471) unsaturated']
+    report = check_comparison_stars(image, TARGET[:2], [[388, 471]], SATURATION, PreflightReport(),
+                                    overexposure_fraction=0.95)
+    assert report.ok
+
+
+def test_blank_sky_comparison_is_flagged_for_a_look():
+    image = frame(stars=[TARGET])
+    report = check_comparison_stars(image, TARGET[:2], [[100, 100]], SATURATION, PreflightReport())
+    assert report.ok
+    assert statuses(report)['comp (100, 100) brightness'] == LOOK
+
+
+def test_comparison_far_brighter_than_target_is_flagged():
+    image = frame(stars=[TARGET, (388, 471, 900.0 * 49)])
+    report = check_comparison_stars(image, TARGET[:2], [[388, 471]], 65535.0, PreflightReport())
+    assert statuses(report)['comp (388, 471) brightness'] == LOOK
+
+
+def test_target_off_frame_fails():
+    report = check_comparison_stars(frame(), (900, 900), [[388, 471]], SATURATION, PreflightReport())
+    assert 'target pixel inside the frame' in report.failures
+
+
+def test_no_saturation_value_skips_saturation_only():
+    image = frame(stars=[TARGET, (388, 471, 60000.0)])
+    report = check_comparison_stars(image, TARGET[:2], [[388, 471]], None, PreflightReport())
+    assert 'comp (388, 471) unsaturated' not in statuses(report)
+
+
+# --- report and CLI --------------------------------------------------------------
+
+def test_report_summary_counts_failures():
+    report = PreflightReport()
+    report.passed(True, 'a')
+    report.passed(False, 'b')
+    report.look(False, 'c')
+    assert report.failures == ['b']
+    assert report.summary().startswith('1 pre-flight check(s) failed')
+    assert [line.strip()[:6] for line in report.lines()] == ['[ok  ]', '[FAIL]', '[look]']
+
+
+def test_preflight_flag_parses(monkeypatch):
+    from exotic import exotic as runtime
+    monkeypatch.setattr('sys.argv', ['exotic', '-pf', 'inits.json'])
+    assert runtime.parse_args().preflight == 'inits.json'
+    monkeypatch.setattr('sys.argv', ['exotic', '-red', 'inits.json'])
+    assert runtime.parse_args().preflight is None
+
+
+# --- end to end on synthetic frames, no network -----------------------------------
+
+def write_night(tmp_path, count=5, target_px=(208, 342), comps=((388, 471), (589, 211)), period=WASP11['pPer']):
+    frames = tmp_path / 'frames'
+    frames.mkdir()
+    tmid, _ = predicted_mid_transit(NIGHT_START, NIGHT_END, WASP11['midT'], WASP11['pPer'])
+    times = np.linspace(tmid - 0.08, tmid + 0.08, count)
+    stars = [TARGET] + [(x, y, 1200.0) for x, y in comps if x < 650 and y < 500]
+    for index, jd in enumerate(times):
+        header = fits.Header()
+        header['MJD-OBS'] = jd - 2400000.5
+        header['EXPTIME'] = 60.0
+        header['TELESCOP'] = 'Cecilia'
+        header['IM_SCALE'] = 5.0
+        fits.PrimaryHDU(data=frame(stars=stars, seed=index).astype(np.float32), header=header).writeto(
+            frames / f'frame{index:02d}.fits')
+    out = tmp_path / 'out'
+    out.mkdir()
+    inits = {
+        'user_info': {
+            'Directory with FITS files': str(frames), 'Directory to Save Plots': str(out),
+            'Directory of Flats': None, 'Directory of Darks': None, 'Directory of Biases': None,
+            'AAVSO Observer Code (blank if none)': '', 'Secondary Observer Codes (blank if none)': '',
+            'Observation date': '2026-09-05', 'Obs. Latitude': '+31.68', 'Obs. Longitude': '-110.88',
+            'Obs. Elevation (meters)': 1268, 'Camera Type (CCD or DSLR)': 'CCD', 'Pixel Binning': '2x2',
+            'Filter Name (aavso.org/filters)': 'CV', 'Observing Notes': '', 'Plate Solution? (y/n)': 'n',
+            'Add Comparison Stars from AAVSO? (y/n)': 'n',
+            'Target Star X & Y Pixel': list(target_px),
+            'Comparison Star(s) X & Y Pixel': [list(c) for c in comps],
+        },
+        'planetary_parameters': {
+            'Target Star RA': '03:09:28.55', 'Target Star Dec': '+30:40:24.2',
+            'Planet Name': 'WASP-11 b', 'Host Star Name': 'WASP-11',
+            'Orbital Period (days)': period, 'Orbital Period Uncertainty': 1.3e-07,
+            'Published Mid-Transit Time (BJD-UTC)': WASP11['midT'], 'Mid-Transit Time Uncertainty': 5e-05,
+            'Ratio of Planet to Stellar Radius (Rp/Rs)': WASP11['rprs'],
+            'Ratio of Planet to Stellar Radius (Rp/Rs) Uncertainty': 0.0004,
+            'Ratio of Distance to Stellar Radius (a/Rs)': WASP11['aRs'],
+            'Ratio of Distance to Stellar Radius (a/Rs) Uncertainty': 0.11,
+            'Orbital Inclination (deg)': WASP11['inc'], 'Orbital Inclination (deg) Uncertainty': 0.5,
+            'Orbital Eccentricity (0 if null)': 0.0, 'Argument of Periastron (deg)': 0.0,
+            'Star Effective Temperature (K)': 4980.0, 'Star Effective Temperature (+) Uncertainty': 60.0,
+            'Star Effective Temperature (-) Uncertainty': -60.0, 'Star Metallicity ([FE/H])': 0.0,
+            'Star Metallicity (+) Uncertainty': 0.2, 'Star Metallicity (-) Uncertainty': -0.2,
+            'Star Surface Gravity (log(g))': 4.45, 'Star Surface Gravity (+) Uncertainty': 0.2,
+            'Star Surface Gravity (-) Uncertainty': -0.2, 'Star Distance (pc)': 124.73,
+            'Star Proper Motion RA (mas/yr)': 3.85579, 'Star Proper Motion DEC (mas/yr)': -44.8259,
+        },
+        'optional_info': {'Exposure Time (s)': 60.0},
+    }
+    path = tmp_path / 'inits.json'
+    path.write_text(json.dumps(inits))
+    return path
+
+
+@pytest.fixture
+def offline_runtime(monkeypatch):
+    from exotic import exotic as runtime
+
+    class FakeArchive:
+        def __init__(self, planet=None, **kwargs):
+            self.planet = planet
+
+        def planet_info(self):
+            return self.planet, False, dict(WASP11, pPerUnc=1.3e-7, midTUnc=5e-5)
+
+    monkeypatch.setattr(runtime, 'NASAExoplanetArchive', FakeArchive)
+    monkeypatch.setattr(runtime, '_preflight_wcs_for_frame', lambda *args, **kwargs: (tan_wcs(), 'test WCS'))
+    return runtime
+
+
+def test_end_to_end_clean_inits_exits_zero(tmp_path, offline_runtime, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    assert offline_runtime.run_inits_preflight(str(write_night(tmp_path))) == 0
+
+
+def test_end_to_end_template_period_exits_one(tmp_path, offline_runtime, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    code = offline_runtime.run_inits_preflight(str(write_night(tmp_path, period=HATP32_SAMPLE_PERIOD)))
+    assert code == 1
+    out = capsys.readouterr().out
+    assert '[FAIL] Orbital Period (days)' in out
+    assert '[FAIL] predicted transit overlaps the window' in out
+
+
+def test_end_to_end_seed_off_target_and_comp_off_frame(tmp_path, offline_runtime, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    code = offline_runtime.run_inits_preflight(
+        str(write_night(tmp_path, target_px=(215, 300), comps=((388, 471), (700, 100)))))
+    assert code == 1
+    out = capsys.readouterr().out
+    assert '[FAIL] target pixel on the target' in out
+    assert '[FAIL] comp (700, 100) inside the frame' in out


### PR DESCRIPTION
Adds `exotic -pf inits.json` (`--preflight`): checks an initialization file before any photometry is run, and exits 1 on a hard failure so a scripted run can gate on it:

```
exotic -pf inits.json && exotic -red inits.json -ov
```

Follows the #exotic thread of 09-08 (Michael: "if its useful in exotic, lets bung it in"; solver order nova first, NextAstro as the fallback).

## What it checks

1. **Archive agreement.** Period (1e-4 relative), Rp/Rs and a/Rs (15%), inclination (2%) against `NASAExoplanetArchive`. Under `-ov` nothing currently compares these, which is how a template copy's ephemeris (the shipped HAT-P-32 b sample's `2.1500082`) survives into a reduction. `check_parameters` only runs without `-ov` and is an interactive prompt. Candidates skip this with a note.
2. **Transit inside the window.** Start/end from every frame's header via `img_time_jd`; epoch nearest the window centre; duration from the existing `estimate_transit_duration_from_prior_geometry`. Fails if the transit does not overlap the window at all; a partial transit is reported for a look, not failed, since the pipeline fits partials.
3. **Seed pixel on the target.** Projects the archive RA/Dec (inits RA/Dec as fallback) through a WCS and compares with `Target Star X & Y Pixel`, tolerance 8 px. Header WCS is used as-is. Otherwise the pipeline's own `get_wcs` runs (nova from a source list first, NextAstro fallback, reversed under `--use-nextastro-astrometry`); since #1414 neither path uploads the image, so the `Plate Solution? (y/n)` answer no longer matters here and the frame is solved exactly as the reduction will solve it. Tries the first three frames by time and says if the seed frame was not frame 1 (EXOTIC seeds from frame 1). Skips cleanly with a note if nothing solves; no local astrometry.net.
4. **Comparison stars on the first frame.** On the frame and below the overexposure threshold (header saturation, e.g. Cecilia 4096, else `saturation_value` at `overexposure_threshold_fraction`, default 0.9) are rules. Brightness relative to the target (5x noise, 0.1-20x) is reported for a look, not failed: one frame is a small sample and on a clouded night the first frame can be the worst one. #1409 rejects off-frame comps after the fact; this says so before the photometry is run.

## Where the code is

- `exotic/api/preflight.py`: the checks as pure functions over plain values (dicts, arrays, a WCS) plus a `PreflightReport` (pass / FAIL / look / skip). No `exotic.exotic` import, so it tests without frames or network.
- `exotic/exotic.py`: `run_inits_preflight` and `_preflight_wcs_for_frame` next to `get_wcs`, the `-pf` argument, and a dispatch at the top of `_main_impl` (guarded with `getattr`, like `quick_look`, for the tests that drive `main()` with a namespace).
- `tests/test_preflight.py`: 27 tests, including three end-to-end runs on synthetic MObs-shaped frames with the archive and the solver monkeypatched (clean file exits 0; template period exits 1 with both the archive and window failures; seed 42 px off plus a comp off the frame exits 1 with both named).

## Evidence

Full suite on this branch: **1179 passed** (tip `0cc46cc` alone: 1152 passed with the same `--ignore=tests/test_quick_look.py`, which needs tkinter this box lacks). The 27 new tests account for the whole difference.

Live run on a real MicroObservatory night (WASP-11 b, 2026-09-05, 93 frames, run before #1414, `Plate Solution? n`, so NextAstro source-list only; ~2 min end to end, most of it the archive scrape):

```
  [ok  ] frames with a readable observation time  93 of 93
  [ok  ] planet found in the NASA Exoplanet Archive  WASP-11 b
  [ok  ] Orbital Period (days)  inits 3.72247975  archive 3.72247975  (0.00% off, tolerance 0.01%)
  [ok  ] Ratio of Planet to Stellar Radius (Rp/Rs)  inits 0.1413  archive 0.14128910290606278  (0.01% off, tolerance 15%)
  [ok  ] Ratio of Distance to Stellar Radius (a/Rs)  inits 12.3  archive 12.3  (0.00% off, tolerance 15%)
  [ok  ] Orbital Inclination (deg)  inits 89.1  archive 89.1  (0.00% off, tolerance 2%)
  [    ] observing window  2461288.82141 -> 2461289.01528  (4.65 h, epoch 1170)
  [ok  ] predicted transit overlaps the window  Tmid 2461288.91662 (+2.29 h from start), duration 2.56 h
  [ok  ] full transit inside the window  ingress +1.00 h  egress +3.57 h from start
  [ok  ] target pixel on the target (frame 1, NextAstro source-list solution)  WCS puts the target at (206.5, 341.4); inits pixel (208, 342) is 1.6 px away (tolerance 8)
  [ok  ] seed frame is the first frame  first frame solved
  [    ] first-frame photometry context  background 426, noise 8, target peak +322 ADU above background
  [ok  ] target unsaturated  peak 748 vs threshold 3686
  [ok  ] comp (388, 471) unsaturated  peak 1024 vs threshold 3686
  [ok  ] comp (388, 471) brightness  +598 ADU above background, 1.9x the target
  ... (six comps, all ok)
All pre-flight checks passed.        exit 0
```

Same night with four errors planted (sample period left in, seed moved 42 px, a comp at [700, 100] on a 650x500 frame):

```
  [FAIL] Orbital Period (days)  inits 2.1500082  archive 3.72247975  (42.24% off, tolerance 0.01%)
  [FAIL] predicted transit overlaps the window  Tmid 2461289.53193 (+17.05 h from start), duration 1.48 h
  [FAIL] target pixel on the target (frame 1, NextAstro source-list solution)  WCS puts the target at (206.5, 341.4); inits pixel (215, 300) is 42.2 px away (tolerance 8)
  [look] comp (388, 471) brightness  +598 ADU above background, 37.4x the target
  [FAIL] comp (700, 100) inside the frame  outside the frame
4 pre-flight check(s) failed. Do not reduce with this file yet.        exit 1
```

The "37x the target" looks are the seed sitting on blank sky (+16 ADU), the same symptom read from the other side.

## One design point to overrule if wanted

- **Partial transits and comp brightness are looks, not failures.** Both are judgment calls in practice; the exit code is reserved for things that are wrong on any reading.

Not touched: the reduction path. `-pf` returns before `reduction_opt` is chosen, so `-red`/`-pre`/`-ql` behave as before.

