### PR TITLE
Plate-solve at nova.astrometry.net from a source list, not the image

### DIFF
--- a/exotic/api/plate_solution.py
+++ b/exotic/api/plate_solution.py
@@ -35,7 +35,7 @@
 #    EXOplanet Transit Interpretation Code (EXOTIC)
 #    # NOTE: See companion file version.py for version info.
 # ########################################################################### #
-from astropy.io.fits import Header, PrimaryHDU, getdata, getheader
+from astropy.io.fits import BinTableHDU, Column, Header, PrimaryHDU, getdata, getheader
 from astropy.stats import sigma_clipped_stats
 from json import dumps
 from pathlib import Path
@@ -63,7 +63,9 @@ _R_MAX_STOPS_LOW = 7
 _R_MAX_STOPS = 10
 _R_MAX_SECS = 37
 _RQ_TIMEOUT = 16.0
-_NEXTASTRO_MAX_SOURCES = 200
+_MAX_SOURCES = 200
+_NEXTASTRO_MAX_SOURCES = _MAX_SOURCES
+_NOVA_XYLIST_FILENAME = "nova_sources.xyls"
 _NEXTASTRO_STATUS_MAX_POLLS = 60
 _NEXTASTRO_STATUS_POLL_SEC = 2
 _NEXTASTRO_IN_PROGRESS_STATUSES = {'queued', 'running'}
@@ -146,7 +148,26 @@ class PlateSolution:
            retry=(retry_if_result(is_false) | retry_if_exception_type(requests.exceptions.RequestException)),
            retry_error_callback=result_if_max_retry_count)
     def _upload(self, session):
-        request_payload = {"session": session}
+        request_payload = self._upload_payload(session)
+
+        with open(self._upload_file(), 'rb') as upload_file:
+            files = {'file': upload_file}
+            r = requests.post(self.api_url + 'upload', files=files,
+                              data={'request-json': dumps(request_payload)}, timeout=_RQ_TIMEOUT)
+
+        if r.json()['status'] == 'success':
+            return r.json()['subid']
+        return False
+
+    def _upload_file(self):
+        return self.file
+
+    def _upload_payload(self, session):
+        # nova reads every option, including the license and visibility flags, from
+        # inside 'request-json' (net/api.py, upload); a bare form field beside it is
+        # ignored and the submission silently defaults to publicly_visible='y'.
+        request_payload = {"session": session, "allow_commercial_use": "n",
+                           "allow_modifications": "n", "publicly_visible": "n"}
 
         if self.ra is not None and self.dec is not None:
             request_payload.update({
@@ -163,16 +184,7 @@ class PlateSolution:
                 "scale_err": float(self.scale_err)
             })
 
-        headers = {'request-json': dumps(request_payload), 'allow_commercial_use': 'n',
-                   'allow_modifications': 'n', 'publicly_visible': 'n'}
-
-        with open(self.file, 'rb') as image_file:
-            files = {'file': image_file}
-            r = requests.post(self.api_url + 'upload', files=files, data=headers, timeout=_RQ_TIMEOUT)
-
-        if r.json()['status'] == 'success':
-            return r.json()['subid']
-        return False
+        return request_payload
 
     @retry(stop=stop_after_attempt(_R_MAX_STOPS), wait=wait_exponential(multiplier=1, min=4, max=_R_MAX_SECS),
            retry=(retry_if_result(is_false) | retry_if_exception_type(requests.exceptions.RequestException)),
@@ -204,61 +216,8 @@ class PlateSolution:
         return False
 
 
-class NextAstroPlateSolution:
-
-    def __init__(self, file=None, directory=None, api_url='https://astrometry.nextastro.org/', ra=None, dec=None,
-                 pixel_scale=None, suppress_fail_warning=False, message_logger=None):
-        self.api_url = api_url.rstrip('/')
-        self.file = file
-        self.directory = directory
-        self.ra = ra
-        self.dec = dec
-        self.pixel_scale = pixel_scale
-        self.suppress_fail_warning = suppress_fail_warning
-        self.message_logger = message_logger
-        self.last_error_type = None
-        self.last_http_status = None
-
-    def plate_solution(self):
-        self.last_error_type = None
-        self.last_http_status = None
-        self._emit_debug(f"Using NextAstro astrometry server at {self.api_url} for plate solving.")
-        source_list = self._generate_source_list()
-        if not source_list:
-            return self._fail('Source extraction for NextAstro astrometry server')
-
-        request_id = self._submit_solve_request(source_list)
-        if not request_id:
-            return self._fail('NextAstro solve submission')
-
-        wcs_header = self._poll_for_solution(request_id)
-        if not wcs_header:
-            return self._fail('NextAstro solve status')
-
-        wcs_file = Path(self.directory) / "working_artifacts" / "wcs.fits"
-        hdu = PrimaryHDU(data=getdata(filename=self.file), header=wcs_header)
-        hdu.writeto(wcs_file, overwrite=True)
-        self._emit_debug("WCS file creation successful.")
-        return wcs_file
-
-    def _emit_debug(self, message):
-        if self.message_logger is not None:
-            self.message_logger(message)
-        elif not self.suppress_fail_warning:
-            print(message)
-
-    @staticmethod
-    def _json_message(payload):
-        try:
-            return dumps(payload)
-        except (TypeError, ValueError):
-            return str(payload)
-
-    def _fail(self, error_type):
-        self.last_error_type = error_type
-        if self.suppress_fail_warning:
-            return False
-        return PlateSolution.fail(error_type, service_name=f'NextAstro ({self.api_url})')
+class _SourceListExtractor:
+    """DAOStarFinder source list from ``self.file``: the brightest _MAX_SOURCES, 0-based pixels."""
 
     def _generate_source_list(self):
         image_data = np.asarray(getdata(filename=self.file), dtype=float)
@@ -337,6 +296,63 @@ class NextAstroPlateSolution:
             "y": y_coords[sorted_indices].tolist(),
             "flux": fluxes[sorted_indices].tolist()
         }
+
+
+class NextAstroPlateSolution(_SourceListExtractor):
+
+    def __init__(self, file=None, directory=None, api_url='https://astrometry.nextastro.org/', ra=None, dec=None,
+                 pixel_scale=None, suppress_fail_warning=False, message_logger=None):
+        self.api_url = api_url.rstrip('/')
+        self.file = file
+        self.directory = directory
+        self.ra = ra
+        self.dec = dec
+        self.pixel_scale = pixel_scale
+        self.suppress_fail_warning = suppress_fail_warning
+        self.message_logger = message_logger
+        self.last_error_type = None
+        self.last_http_status = None
+
+    def plate_solution(self):
+        self.last_error_type = None
+        self.last_http_status = None
+        self._emit_debug(f"Using NextAstro astrometry server at {self.api_url} for plate solving.")
+        source_list = self._generate_source_list()
+        if not source_list:
+            return self._fail('Source extraction for NextAstro astrometry server')
+
+        request_id = self._submit_solve_request(source_list)
+        if not request_id:
+            return self._fail('NextAstro solve submission')
+
+        wcs_header = self._poll_for_solution(request_id)
+        if not wcs_header:
+            return self._fail('NextAstro solve status')
+
+        wcs_file = Path(self.directory) / "working_artifacts" / "wcs.fits"
+        hdu = PrimaryHDU(data=getdata(filename=self.file), header=wcs_header)
+        hdu.writeto(wcs_file, overwrite=True)
+        self._emit_debug("WCS file creation successful.")
+        return wcs_file
+
+    def _emit_debug(self, message):
+        if self.message_logger is not None:
+            self.message_logger(message)
+        elif not self.suppress_fail_warning:
+            print(message)
+
+    @staticmethod
+    def _json_message(payload):
+        try:
+            return dumps(payload)
+        except (TypeError, ValueError):
+            return str(payload)
+
+    def _fail(self, error_type):
+        self.last_error_type = error_type
+        if self.suppress_fail_warning:
+            return False
+        return PlateSolution.fail(error_type, service_name=f'NextAstro ({self.api_url})')
 
     @staticmethod
     def _response_body_preview(response, max_chars=240):
@@ -453,3 +469,64 @@ class NextAstroPlateSolution:
 
         self._emit_debug(f"[NextAstro] Polling timed out waiting for terminal status; latest status={latest_status!r}")
         return False
+
+
+class NovaSourceListPlateSolution(_SourceListExtractor, PlateSolution):
+    """Plate-solve at nova.astrometry.net from a source list instead of the image.
+
+    Builds the same DAOStarFinder list EXOTIC sends to NextAstro, writes it as a
+    FITS binary table (X, Y, FLUX) and uploads that with the frame's dimensions;
+    nova recognises an xylist by itself, no other API change. Login, submission
+    and job polling are inherited unchanged from PlateSolution, so a slow nova
+    queue hands off to the next solver at exactly the point an image upload
+    would. Pixels are written 1-based, the FITS convention nova reads: on a
+    WASP-11 frame the 1-based list put the target 0.6 px from its seed, the
+    0-based list 1.6 px. The list is ~60x smaller than the frame and no pixels
+    leave the machine.
+
+    nova has no cancel route (net/api.py: login, upload, url_upload,
+    submissions, jobs, calibration, tags, info, annotations, myjobs,
+    jobs_by_tag), so a submission we stop polling for still runs when its turn
+    comes; with a source list that is about a second of solver time. If nova
+    ever grows one, ``_sub_status`` running out of attempts is where it belongs.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.xylist_file = None
+        self.image_shape = None
+
+    def plate_solution(self):
+        self.last_error_type = None
+        if not self._write_source_list():
+            return self._fail('Source extraction')
+        return super().plate_solution()
+
+    def _write_source_list(self):
+        source_list = self._generate_source_list()
+        if not source_list:
+            return None
+        image_data = getdata(filename=self.file)
+        self.image_shape = (int(image_data.shape[-2]), int(image_data.shape[-1]))
+
+        # EXOTIC's extractor is 0-based; nova reads xylists 1-based.
+        x = np.asarray(source_list['x'], dtype=float) + 1.0
+        y = np.asarray(source_list['y'], dtype=float) + 1.0
+        flux = np.asarray(source_list['flux'], dtype=float)
+        table = BinTableHDU.from_columns([Column(name='X', format='D', array=x),
+                                          Column(name='Y', format='D', array=y),
+                                          Column(name='FLUX', format='D', array=flux)])
+
+        xylist_file = Path(self.directory) / "working_artifacts" / _NOVA_XYLIST_FILENAME
+        xylist_file.parent.mkdir(parents=True, exist_ok=True)
+        table.writeto(xylist_file, overwrite=True)
+        self.xylist_file = xylist_file
+        return xylist_file
+
+    def _upload_file(self):
+        return self.xylist_file
+
+    def _upload_payload(self, session):
+        request_payload = super()._upload_payload(session)
+        request_payload.update({"image_width": self.image_shape[1], "image_height": self.image_shape[0]})
+        return request_payload

--- a/exotic/exotic.py
+++ b/exotic/exotic.py
@@ -140,9 +140,9 @@ try:  # ld
 except ImportError:  # package import
     from api.ld import LimbDarkening, ld_re_punct_p
 try:  # plate solution
-    from .api.plate_solution import NextAstroPlateSolution, PlateSolution
+    from .api.plate_solution import NextAstroPlateSolution, NovaSourceListPlateSolution, PlateSolution
 except ImportError:  # package import
-    from api.plate_solution import NextAstroPlateSolution, PlateSolution
+    from api.plate_solution import NextAstroPlateSolution, NovaSourceListPlateSolution, PlateSolution
 try:
     from .api.ultranest_utils import (
         get_mpi_status,
@@ -16258,7 +16258,7 @@ def should_use_multiprocess_transform_precompute(inputfiles, requested_processes
 
 
 def get_wcs(file, directory="", use_nextastro_astrometry=False, ra=None, dec=None, pixel_scale=None):
-    astrometry_service = 'NextAstro astrometry server (https://astrometry.nextastro.org/)' if use_nextastro_astrometry else 'nova.astrometry.net'
+    astrometry_service = 'NextAstro astrometry server (https://astrometry.nextastro.org/)' if use_nextastro_astrometry else 'nova.astrometry.net (source list)'
     log_info("\nGetting the plate solution for your imaging file to translate pixel coordinates on the sky. "
              f"\nUsing astrometry service: {astrometry_service}."
              "\nPlease wait....")
@@ -16284,8 +16284,8 @@ def get_wcs(file, directory="", use_nextastro_astrometry=False, ra=None, dec=Non
         else:
             log_info("NextAstro astrometry server did not return a solution; falling back to nova.astrometry.net.")
         print("Communication with nova.astrometry.net")
-        nova_solver = PlateSolution(file=file, directory=directory, ra=ra, dec=dec,
-                                    pixel_scale=pixel_scale, suppress_fail_warning=True)
+        nova_solver = NovaSourceListPlateSolution(file=file, directory=directory, ra=ra, dec=dec,
+                                                  pixel_scale=pixel_scale, suppress_fail_warning=True)
         wcs_file = nova_solver.plate_solution()
         if wcs_file:
             return wcs_file
@@ -16295,8 +16295,8 @@ def get_wcs(file, directory="", use_nextastro_astrometry=False, ra=None, dec=Non
         return PlateSolution.fail(nova_solver.last_error_type or 'plate solution lookup')
 
     animate_toggle(True)
-    nova_solver = PlateSolution(file=file, directory=directory, ra=ra, dec=dec,
-                                pixel_scale=pixel_scale, suppress_fail_warning=True)
+    nova_solver = NovaSourceListPlateSolution(file=file, directory=directory, ra=ra, dec=dec,
+                                              pixel_scale=pixel_scale, suppress_fail_warning=True)
     wcs_file = nova_solver.plate_solution()
     if wcs_file:
         animate_toggle()

--- a/tests/test_nextastro_variability.py
+++ b/tests/test_nextastro_variability.py
@@ -2236,7 +2236,7 @@ def test_get_wcs_falls_back_to_nextastro_when_nova_fails(monkeypatch):
             service_calls.append('nextastro')
             return 'nextastro-wcs'
 
-    monkeypatch.setattr(exotic_module, 'PlateSolution', DummyPlateSolution)
+    monkeypatch.setattr(exotic_module, 'NovaSourceListPlateSolution', DummyPlateSolution)
     monkeypatch.setattr(exotic_module, 'NextAstroPlateSolution', DummyNextAstroSolution)
     monkeypatch.setattr(exotic_module, 'animate_toggle', lambda *args, **kwargs: None)
 
@@ -2268,7 +2268,7 @@ def test_get_wcs_logs_nextastro_bad_gateway_before_nova_fallback(monkeypatch):
             service_calls.append('nextastro')
             return False
 
-    monkeypatch.setattr(exotic_module, 'PlateSolution', DummyPlateSolution)
+    monkeypatch.setattr(exotic_module, 'NovaSourceListPlateSolution', DummyPlateSolution)
     monkeypatch.setattr(exotic_module, 'NextAstroPlateSolution', DummyNextAstroSolution)
     monkeypatch.setattr(exotic_module, 'animate_toggle', lambda *args, **kwargs: None)
     monkeypatch.setattr(exotic_module, 'log_info', lambda message, warn=False, error=False: logged.append(message))
@@ -2302,7 +2302,7 @@ def test_get_wcs_logs_nextastro_bad_gateway_after_both_methods_fail(monkeypatch)
             service_calls.append('nextastro')
             return False
 
-    monkeypatch.setattr(exotic_module, 'PlateSolution', DummyPlateSolution)
+    monkeypatch.setattr(exotic_module, 'NovaSourceListPlateSolution', DummyPlateSolution)
     monkeypatch.setattr(exotic_module, 'NextAstroPlateSolution', DummyNextAstroSolution)
     monkeypatch.setattr(exotic_module, 'animate_toggle', lambda *args, **kwargs: None)
     monkeypatch.setattr(exotic_module, 'log_info', lambda message, warn=False, error=False: logged.append(message))

--- a/tests/test_nova_source_list.py
+++ b/tests/test_nova_source_list.py
@@ -1,0 +1,166 @@
+import io
+import json
+from pathlib import Path
+
+import numpy as np
+from astropy.io.fits import getdata, getheader, writeto
+from astropy.io import fits
+
+from exotic.api.plate_solution import NextAstroPlateSolution, NovaSourceListPlateSolution, PlateSolution
+
+
+class DummyResponse:
+    def __init__(self, payload, status_code=200, content=b''):
+        self._payload = payload
+        self.status_code = status_code
+        self.content = content
+
+    def json(self):
+        return self._payload
+
+
+def _create_test_fits(tmp_path: Path) -> Path:
+    image = np.zeros((100, 120), dtype=float)
+    image[30, 25] = 10000.0
+    image[70, 80] = 8000.0
+    image[50, 60] = 7000.0
+    fits_path = tmp_path / "image.fits"
+    writeto(fits_path, image, overwrite=True)
+    return fits_path
+
+
+def _wcs_bytes():
+    header = fits.Header()
+    header['CTYPE1'] = 'RA---TAN'
+    header['CTYPE2'] = 'DEC--TAN'
+    header['CRVAL1'] = 150.0
+    header['CRVAL2'] = -2.0
+    header['CRPIX1'] = 60.0
+    header['CRPIX2'] = 50.0
+    header['CDELT1'] = -0.0004
+    header['CDELT2'] = 0.0004
+    buffer = io.BytesIO()
+    fits.PrimaryHDU(header=header).writeto(buffer)
+    return buffer.getvalue()
+
+
+def test_source_list_is_shared_with_nextastro(tmp_path):
+    fits_path = _create_test_fits(tmp_path)
+    nova = NovaSourceListPlateSolution(file=fits_path, directory=tmp_path)._generate_source_list()
+    nextastro = NextAstroPlateSolution(file=fits_path, directory=tmp_path)._generate_source_list()
+    assert nova == nextastro
+    assert nova["pixel_indexing"] == "0-based"
+
+
+def test_xylist_is_one_based_with_image_dims_and_private_flags(tmp_path, monkeypatch):
+    fits_path = _create_test_fits(tmp_path)
+    solver = NovaSourceListPlateSolution(file=fits_path, directory=tmp_path, ra=150.123, dec=-2.456, pixel_scale=1.5)
+    source_list = solver._generate_source_list()
+
+    captured = {}
+
+    def fake_post(url, files, data, timeout):
+        captured['url'] = url
+        captured['request_json'] = json.loads(data['request-json'])
+        captured['upload_name'] = Path(files['file'].name).name
+        captured['table'] = getdata(files['file'].name, ext=1)
+        return DummyResponse({'status': 'success', 'subid': 42})
+
+    monkeypatch.setattr('exotic.api.plate_solution.requests.post', fake_post)
+
+    assert solver._write_source_list() is not None
+    assert solver._upload(session='session-id') == 42
+
+    assert captured['url'].endswith('/upload')
+    assert captured['upload_name'] == 'nova_sources.xyls'
+    table = captured['table']
+    assert list(table.columns.names) == ['X', 'Y', 'FLUX']
+    np.testing.assert_allclose(table['X'], np.asarray(source_list['x']) + 1.0)
+    np.testing.assert_allclose(table['Y'], np.asarray(source_list['y']) + 1.0)
+    np.testing.assert_allclose(table['FLUX'], source_list['flux'])
+
+    request_json = captured['request_json']
+    assert request_json['session'] == 'session-id'
+    assert request_json['image_width'] == 120
+    assert request_json['image_height'] == 100
+    assert request_json['publicly_visible'] == 'n'
+    assert request_json['allow_commercial_use'] == 'n'
+    assert request_json['allow_modifications'] == 'n'
+    assert request_json['center_ra'] == 150.123
+    assert request_json['center_dec'] == -2.456
+    assert request_json['scale_est'] == 1.5
+    assert request_json['scale_units'] == 'arcsecperpix'
+
+
+def test_image_upload_puts_visibility_flags_inside_request_json(tmp_path, monkeypatch):
+    fits_path = _create_test_fits(tmp_path)
+    captured = {}
+
+    def fake_post(url, files, data, timeout):
+        captured['form_keys'] = set(data)
+        captured['request_json'] = json.loads(data['request-json'])
+        captured['upload_name'] = Path(files['file'].name).name
+        return DummyResponse({'status': 'success', 'subid': 7})
+
+    monkeypatch.setattr('exotic.api.plate_solution.requests.post', fake_post)
+
+    assert PlateSolution(file=fits_path, directory=tmp_path)._upload(session='s') == 7
+    assert captured['upload_name'] == 'image.fits'
+    assert captured['form_keys'] == {'request-json'}
+    assert captured['request_json']['publicly_visible'] == 'n'
+    assert 'image_width' not in captured['request_json']
+
+
+def test_plate_solution_runs_the_inherited_nova_flow(tmp_path, monkeypatch):
+    fits_path = _create_test_fits(tmp_path)
+    calls = []
+
+    def fake_post(url, data, timeout, files=None):
+        calls.append(url)
+        if url.endswith('/login'):
+            assert json.loads(data['request-json']) == {'apikey': 'vfsyxlmdxfryhprq'}
+            return DummyResponse({'status': 'success', 'session': 'sess'})
+        if url.endswith('/upload'):
+            assert Path(files['file'].name).name == 'nova_sources.xyls'
+            assert json.loads(data['request-json'])['session'] == 'sess'
+            return DummyResponse({'status': 'success', 'subid': 5})
+        raise AssertionError(url)
+
+    def fake_get(url, timeout):
+        calls.append(url)
+        if url.endswith('/submissions/5'):
+            return DummyResponse({'job_calibrations': [[9, 1]], 'jobs': [9]})
+        if url.endswith('/jobs/9'):
+            return DummyResponse({'status': 'success'})
+        if url.endswith('/wcs_file/9/'):
+            return DummyResponse(None, content=_wcs_bytes())
+        raise AssertionError(url)
+
+    monkeypatch.setattr('exotic.api.plate_solution.requests.post', fake_post)
+    monkeypatch.setattr('exotic.api.plate_solution.requests.get', fake_get)
+
+    solver = NovaSourceListPlateSolution(file=fits_path, directory=tmp_path, suppress_fail_warning=True)
+    wcs_file = solver.plate_solution()
+
+    assert wcs_file == tmp_path / 'working_artifacts' / 'wcs.fits'
+    assert (tmp_path / 'working_artifacts' / 'nova_sources.xyls').exists()
+    assert getheader(wcs_file)['CTYPE1'] == 'RA---TAN'
+    assert getdata(wcs_file).shape == (100, 120)
+    assert [c.rsplit('/api/', 1)[-1] if '/api/' in c else c for c in calls] == [
+        'login', 'upload', 'submissions/5', 'jobs/9', 'http://nova.astrometry.net/wcs_file/9/']
+    assert solver.last_error_type is None
+
+
+def test_blank_frame_fails_before_any_request(tmp_path, monkeypatch):
+    fits_path = tmp_path / "blank.fits"
+    writeto(fits_path, np.zeros((50, 50), dtype=float), overwrite=True)
+
+    def no_network(*args, **kwargs):
+        raise AssertionError('no request expected')
+
+    monkeypatch.setattr('exotic.api.plate_solution.requests.post', no_network)
+    monkeypatch.setattr('exotic.api.plate_solution.requests.get', no_network)
+
+    solver = NovaSourceListPlateSolution(file=fits_path, directory=tmp_path, suppress_fail_warning=True)
+    assert solver.plate_solution() is False
+    assert solver.last_error_type == 'Source extraction'


### PR DESCRIPTION
Follows the #1413 thread in #exotic (Michael's "sounds fine", 09-09). `NovaSourceListPlateSolution` builds the same DAOStarFinder list EXOTIC already sends to NextAstro, writes it as a FITS binary table (X, Y, FLUX) and uploads that to nova's `/upload` with `image_width`/`image_height` plus the usual scale and RA/Dec hints. nova recognises an xylist by itself; no other API change. Login, submission and job polling are inherited unchanged from `PlateSolution`, so a slow nova queue hands off to NextAstro at exactly the point an image upload would. The list is ~60x smaller than a frame and no pixels leave the machine.

`get_wcs` now uses it wherever it used the image upload (nova-first default and the NextAstro-first `--use-nextastro-astrometry` fallback). The image class stays in the module, unused by `get_wcs`.

**What I found while factoring the upload payload, and fixed in the same change.** nova reads `allow_commercial_use`, `allow_modifications` and `publicly_visible` from *inside* `request-json` ([net/api.py, `upload`](https://github.com/dstndstn/astrometry.net/blob/main/net/api.py): `json.get('publicly_visible', 'y')`). The old `_upload` sent them as bare form fields beside `request-json`, which nova ignores, so every image EXOTIC has uploaded to nova defaulted to public. They are inside `request-json` now, for both classes; there is a test pinning that.

**Pixel convention.** EXOTIC's extractor is 0-based; nova reads xylists 1-based (FITS). The writer adds 1. On WASP-11 09-05 frame 1 the 1-based list put the target 0.6 px from its seed, the 0-based list 1.6 px. NextAstro's own WCS on this frame matched the 0-based nova result; the payload says `"pixel_indexing": "0-based"`, so either NextAstro reads that field or it is ~1 px off. Worth a look by whoever owns that server; not touched here.

**No cancel.** Checked nova's routes rather than memory (`net/urls.py`, `net/api.py`): login, upload, url_upload, submissions, jobs, calibration, tags, info, annotations, myjobs, jobs_by_tag; web side only has hide/unhide. A submission we stop polling for still runs when its turn comes. With a source list that is about a second of solver time. The docstring says so and names `_sub_status` running out as the place a cancel call would go.

**Live run** (this branch, `NovaSourceListPlateSolution(...).plate_solution()` on WASP-11 09-05 frame 1, 650x500, tonight's queue): solved in 186 s, xylist 11,520 bytes against a 656,640-byte frame, `wcs.fits` written with the image data (500, 650), target at (207.5, 342.4) against seed (208, 342), 0.6 px. Last night's two hand-rolled list uploads took 56 s and 325 s; the wait is nova's queue, not the solve.

**Tests.** `tests/test_nova_source_list.py`: shared extractor gives the identical list to NextAstro; xylist is 1-based with the right columns, image dims and private flags in `request-json`; the image class now puts the flags in `request-json` too; the full inherited login/upload/submission/job/wcs flow against mocked `requests`; a blank frame fails at `Source extraction` before any request. Three `get_wcs` tests in `test_nextastro_variability.py` repointed at the new class. 1154 pass; `test_quick_look.py` needs tkinter, which this venv lacks, and errors on the clean branch too.

**Answered in #exotic (Michael, 09-10): dropped.** The size argument is his and it is the stronger one: the source list scales with the 200-source cap, not the sensor, so it stays ~10 KB while a QHY600 frame is ~250 MB. MicroObservatory's small frames hide the issue; many users' connections would not carry the image at all.

~~**Question for you.** With this in, `get_wcs` never uploads an image. Do you want the image upload kept as an explicit last tier (source list to nova, then NextAstro, then image to nova), or dropped from the path as here? I lean dropped: the failure modes of a source list that does not solve are mostly the same frames an image would not solve, and it keeps the "no pixels leave the machine" statement simple.~~

Once this lands, #1413 gets a follow-up commit: `_preflight_wcs_for_frame` just calls `get_wcs` and the `Plate Solution?` branch goes, since the answer no longer changes what leaves the machine. I am holding that until this merges so a 'n' user does not upload an image if #1413 lands first.

