### PR TITLE
Carry the pre-fit transit coverage verdict into the final plot title and the AAVSO #NOTES

### DIFF
--- a/exotic/output_files.py
+++ b/exotic/output_files.py
@@ -3827,10 +3827,7 @@ def transit_coverage_caption(fit):
         observed = f"{100.0 * float(assessment.get('transit_fraction_observed')):.0f}%"
     except (TypeError, ValueError):
         observed = "?%"
-    return (
-        f"COVERAGE: {segment}; {observed} of the expected transit window observed; "
-        f"fit success {str(label).upper()}"
-    )
+    return f"COVERAGE {observed}: {segment}; fit success {str(label).upper()}"
 
 
 def aavso_notes_text(notes, fit):

--- a/exotic/output_files.py
+++ b/exotic/output_files.py
@@ -3344,7 +3344,7 @@ class OutputFiles:
                     f"{gaia_pmra_header}"
                     f"{gaia_pmdec_header}"
                     f"#COMP_STAR-XC={dumps(comp_star)}\n"
-                    f"#NOTES={self.i_dict['notes']}\n"
+                    f"#NOTES={aavso_notes_text(self.i_dict['notes'], self.fit)}\n"
                     "#DETREND_PARAMETERS=AIRMASS, AIRMASS CORRECTION FUNCTION\n"  # fixed
                     "#MEASUREMENT_TYPE=Rnflux\n"  # fixed
                     f"#FILTER={self.i_dict['filter']}\n"
@@ -3796,6 +3796,52 @@ def aavso_dicts(planet_dict, fit, info_dict, durs, ld0, ld1, ld2, ld3):
     })
 
     return priors, filter_type, results
+
+
+
+def transit_coverage_caption(fit):
+    """One line for a fit whose timestamps did not cover the expected transit.
+
+    The pre-UltraNest coverage assessment already says, in the log, when the
+    observed points do not overlap the ephemeris-predicted transit window and
+    the fit is not expected to succeed.  The fit still runs, still draws a
+    model, still writes an AAVSO file, and the observer reads the plot and the
+    file, not the log.  This puts the same verdict where it will be seen.
+
+    Returns None when the assessment was not run, was invalid, or expected the
+    fit to succeed, so covered nights are unchanged.
+    """
+    if fit is None or not getattr(fit, 'pre_ultranest_transit_coverage_valid', False):
+        return None
+    if getattr(fit, 'pre_ultranest_transit_coverage_expected_successful', True):
+        return None
+    assessment = getattr(fit, 'pre_ultranest_transit_coverage', None)
+    assessment = assessment if isinstance(assessment, dict) else {}
+    segment = assessment.get('observed_segment') or 'coverage unknown'
+    label = (
+        getattr(fit, 'pre_ultranest_transit_coverage_status', None)
+        or assessment.get('success_label')
+        or 'unknown'
+    )
+    try:
+        observed = f"{100.0 * float(assessment.get('transit_fraction_observed')):.0f}%"
+    except (TypeError, ValueError):
+        observed = "?%"
+    return (
+        f"COVERAGE: {segment}; {observed} of the expected transit window observed; "
+        f"fit success {str(label).upper()}"
+    )
+
+
+def aavso_notes_text(notes, fit):
+    """The #NOTES value: the observer's notes, plus EXOTIC's own coverage verdict
+    when the observed timestamps did not cover the expected transit window."""
+    caption = transit_coverage_caption(fit)
+    if not caption:
+        return "" if notes is None else str(notes)
+    notes_text = format_aavso_header_value(notes)
+    caption = f"EXOTIC {caption}"
+    return f"{notes_text} | {caption}" if notes_text else caption
 
 
 def format_aavso_header_value(value):

--- a/exotic/plots.py
+++ b/exotic/plots.py
@@ -34,6 +34,7 @@ try:
         fit_empirical_transit_uncertainty,
         fit_impact_parameter_value_error,
         fit_parameter_model_data_uncertainty,
+        transit_coverage_caption,
     )
 except ImportError:
     from .output_files import (
@@ -42,6 +43,7 @@ except ImportError:
         fit_empirical_transit_uncertainty,
         fit_impact_parameter_value_error,
         fit_parameter_model_data_uncertainty,
+        transit_coverage_caption,
     )
 
 plt.style.use(astropy_mpl_style)
@@ -1484,6 +1486,9 @@ def _build_final_lightcurve_figure(
         title = f"{targ_name}\nFULL DATA / FULL LIGHT CURVE (DIAGNOSTIC)"
     else:
         title = targ_name
+    coverage_caption = transit_coverage_caption(fit)
+    if coverage_caption:
+        title = f"{title}\n{coverage_caption}"
     ax_lc.set_title(title)
 
     drew_data_scatter_band = _plot_final_data_scatter_uncertainty_band(ax_lc, fit, high_res)

--- a/exotic/plots.py
+++ b/exotic/plots.py
@@ -1492,6 +1492,14 @@ def _build_final_lightcurve_figure(
         # that wide would be clipped on the square and 16:9 PNGs.
         title = f"{title}\n{coverage_caption.replace('; ', chr(10))}"
     ax_lc.set_title(title)
+    if coverage_caption:
+        # The fitter lays the figure out with top=0.92 for a one-line title;
+        # the presentation PNG renders without bbox trimming, so make room for
+        # the two extra lines or the target name is clipped off the top.
+        try:
+            f.subplots_adjust(top=0.84)
+        except Exception:
+            pass
 
     drew_data_scatter_band = _plot_final_data_scatter_uncertainty_band(ax_lc, fit, high_res)
     if hasattr(fit, 'phase_upsample') and hasattr(fit, 'transit_upsample'):

--- a/exotic/plots.py
+++ b/exotic/plots.py
@@ -1488,7 +1488,9 @@ def _build_final_lightcurve_figure(
         title = targ_name
     coverage_caption = transit_coverage_caption(fit)
     if coverage_caption:
-        title = f"{title}\n{coverage_caption}"
+        # Two short lines: the one-line form is for the AAVSO #NOTES; a title
+        # that wide would be clipped on the square and 16:9 PNGs.
+        title = f"{title}\n{coverage_caption.replace('; ', chr(10))}"
     ax_lc.set_title(title)
 
     drew_data_scatter_band = _plot_final_data_scatter_uncertainty_band(ax_lc, fit, high_res)

--- a/tests/test_output_files.py
+++ b/tests/test_output_files.py
@@ -12,6 +12,7 @@ from exotic.output_files import (
     AIDOutputFiles,
     OutputFiles,
     aavso_detrend_model,
+    aavso_notes_text,
     aid_comparison_coordinate_headers,
     aavso_dicts,
     aavso_undetrended_flux_series,
@@ -2429,3 +2430,29 @@ def test_aavso_output_includes_extended_diagnostic_comment_headers(tmp_path):
     assert bad_pixel["enabled"] is True
     assert bad_pixel["bad_pixel_count"] == 3
     assert bad_pixel["counts_path"] == "BadPixelDetectionCounts.fits"
+
+
+def test_aavso_notes_carry_the_coverage_verdict_only_when_the_fit_was_not_expected_to_succeed():
+    uncovered = SimpleNamespace(
+        pre_ultranest_transit_coverage_valid=True,
+        pre_ultranest_transit_coverage_expected_successful=False,
+        pre_ultranest_transit_coverage_status="very low",
+        pre_ultranest_transit_coverage={
+            "observed_segment": "pre-transit baseline only",
+            "transit_fraction_observed": 0.0,
+        },
+    )
+    caption = (
+        "EXOTIC COVERAGE: pre-transit baseline only; 0% of the expected transit window "
+        "observed; fit success VERY LOW"
+    )
+    assert aavso_notes_text("MObs night", uncovered) == f"MObs night | {caption}"
+    assert aavso_notes_text("na", uncovered) == caption
+    assert aavso_notes_text("", uncovered) == caption
+
+    covered = SimpleNamespace(
+        pre_ultranest_transit_coverage_valid=True,
+        pre_ultranest_transit_coverage_expected_successful=True,
+    )
+    assert aavso_notes_text("na", covered) == "na"
+    assert aavso_notes_text("MObs night", DummyFit()) == "MObs night"

--- a/tests/test_output_files.py
+++ b/tests/test_output_files.py
@@ -2442,10 +2442,7 @@ def test_aavso_notes_carry_the_coverage_verdict_only_when_the_fit_was_not_expect
             "transit_fraction_observed": 0.0,
         },
     )
-    caption = (
-        "EXOTIC COVERAGE: pre-transit baseline only; 0% of the expected transit window "
-        "observed; fit success VERY LOW"
-    )
+    caption = "EXOTIC COVERAGE 0%: pre-transit baseline only; fit success VERY LOW"
     assert aavso_notes_text("MObs night", uncovered) == f"MObs night | {caption}"
     assert aavso_notes_text("na", uncovered) == caption
     assert aavso_notes_text("", uncovered) == caption

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -1044,3 +1044,67 @@ def test_plot_ktmf_qc_metrics_writes_outputs_and_annotations(tmp_path, monkeypat
 
 def test_ktmf_plot_shortens_tmid_posterior_gaussianity_label():
     assert _short_ktmf_label("Tmid Posterior Gaussianity") == "Tmid Gaussianity"
+
+
+def test_final_lightcurve_title_carries_low_coverage_verdict():
+    class DummyFinalFit:
+        def __init__(self):
+            self.phase_upsample = np.linspace(-0.05, 0.05, 5)
+            self.transit_upsample = np.ones(5)
+            self.pre_ultranest_transit_coverage_valid = True
+            self.pre_ultranest_transit_coverage_expected_successful = False
+            self.pre_ultranest_transit_coverage_status = "very low"
+            self.pre_ultranest_transit_coverage = {
+                "valid": True,
+                "observed_segment": "pre-transit baseline only",
+                "transit_fraction_observed": 0.0,
+                "success_label": "very low",
+            }
+
+        def plot_bestfit(self, **kwargs):
+            fig, axes = plt.subplots(2, 1)
+            return fig, axes
+
+    fit = DummyFinalFit()
+    figure = plots_module._build_final_lightcurve_figure(
+        fit,
+        np.ones(5),
+        "Target",
+        show_restricted_baseline_points=False,
+        show_binned_points=False,
+    )
+    title = figure.axes[0].get_title()
+    plt.close(figure)
+
+    assert title.splitlines()[0] == "Target"
+    assert (
+        "COVERAGE: pre-transit baseline only; 0% of the expected transit window observed; "
+        "fit success VERY LOW"
+    ) in title
+
+
+def test_final_lightcurve_title_is_unchanged_when_coverage_was_expected_to_succeed():
+    class DummyFinalFit:
+        def __init__(self):
+            self.phase_upsample = np.linspace(-0.05, 0.05, 5)
+            self.transit_upsample = np.ones(5)
+            self.pre_ultranest_transit_coverage_valid = True
+            self.pre_ultranest_transit_coverage_expected_successful = True
+            self.pre_ultranest_transit_coverage = {"observed_segment": "full transit"}
+
+        def plot_bestfit(self, **kwargs):
+            fig, axes = plt.subplots(2, 1)
+            return fig, axes
+
+    figure = plots_module._build_final_lightcurve_figure(
+        DummyFinalFit(),
+        np.ones(5),
+        "Target",
+        show_restricted_baseline_points=False,
+        show_binned_points=False,
+    )
+    title = figure.axes[0].get_title()
+    plt.close(figure)
+
+    assert title == "Target"
+    assert plots_module.transit_coverage_caption(SimpleNamespace()) is None

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -1077,10 +1077,10 @@ def test_final_lightcurve_title_carries_low_coverage_verdict():
     plt.close(figure)
 
     assert title.splitlines()[0] == "Target"
-    assert (
-        "COVERAGE: pre-transit baseline only; 0% of the expected transit window observed; "
-        "fit success VERY LOW"
-    ) in title
+    assert title.splitlines()[1:] == [
+        "COVERAGE 0%: pre-transit baseline only",
+        "fit success VERY LOW",
+    ]
 
 
 def test_final_lightcurve_title_is_unchanged_when_coverage_was_expected_to_succeed():


### PR DESCRIPTION
## What

When the pre-UltraNest coverage assessment finds that the observed timestamps do not cover the ephemeris-predicted transit window and does not expect the fit to succeed, put that one line where the observer will see it:

- as a second line of the final light-curve title (`FinalLightCurve_*.png`, and the `_HighRes` copy);
- appended to `#NOTES=` in the AAVSO file (or alone when the observer's notes are empty / `na`).

`transit_coverage_caption(fit)` in `output_files.py` reads the assessment that `annotate_pre_ultranest_transit_coverage` already attaches to the fit. It returns `None` unless the assessment ran, is valid, and `expected_successful` is false, so covered nights produce byte-identical outputs. `#QC-XC` already carries `status` machine-readably; this is the human-readable copy.

Example line:

```
COVERAGE 0%: pre-transit baseline only; fit success VERY LOW
```

(two title lines on the plot, split at the `; `; one line in `#NOTES`, prefixed `EXOTIC`)

## Why (a night from yesterday)

MObs WASP-10 b, 2026-09-11 UT, 29 frames 06:06-07:31 UT. By the archive ephemeris (P 3.0927616, T0 2454664.037295, epoch 2144) ingress is 08:55 and mid-transit 10:02 UT, so the last frame is 84 min before ingress. The log at d77c750 says so, three times, once per comparison candidate:

```
Expected transit window: ingress 2461294.87140196, mid 2461294.91816540, egress 2461294.96492884 BJD_TDB (duration 134.7 min).
Observed coverage: pre-transit baseline only; 0.0% of the expected transit window with 27 pre-ingress, 0 in-transit, and 0 post-egress point(s).
Estimated fit success: VERY LOW (~5%). The observed timestamps do not overlap the expected transit window; UltraNest is unlikely to recover a constrained transit solution.
```

Then transit QC fails on every candidate (KTMF 2.33/5.00) and the run continues "with the best available fit so final outputs are still produced". The outputs: a plot titled `WASP-10 b` with a model ingress drawn through the last five points, `Mid-Transit Time [BJD_TDB]: 2461294.8448 +/- 0.0083` (08:20 UT, 50 min after the last frame, 101 min before the ephemeris, with a 12-minute bar), and an AAVSO file whose `#NOTES` is the observer's own text. Nothing the observer reads says the fit is an extrapolation. The same night, reduced by another observer with the same seed pixel and the same comp, was uploaded to #data-upload-aavso yesterday with `Tmid 2461294.8486 +/- 0.0086`; the two runs agree with each other because both are the same extrapolation.

With this change the plot title carries `COVERAGE 0%: pre-transit baseline only` / `fit success VERY LOW` under the target name, and `#NOTES` ends with `| EXOTIC COVERAGE 0%: pre-transit baseline only; fit success VERY LOW`. (A second run on the same frames with this branch is in progress; I will attach the annotated plot in a comment when it finishes.)

Not in this PR: putting the transit-QC verdict itself on the plot. That may be worth doing too, but it is a separate decision about the KTMF outputs; this one only surfaces a verdict EXOTIC has already made before the fit began.

## Tests

`tests/test_plots.py`: title carries the line for an uncovered fit; unchanged for a covered fit and for a fit without the assessment. `tests/test_output_files.py`: `aavso_notes_text` with observer notes, `na`, empty, a covered fit, and the existing `DummyFit`.

```
python -m pytest -q tests/test_plots.py tests/test_output_files.py
76 passed
```
